### PR TITLE
Base: Allow paying relayed actions with any token

### DIFF
--- a/packages/base/contracts/actions/RelayedAction.sol
+++ b/packages/base/contracts/actions/RelayedAction.sol
@@ -39,9 +39,6 @@ abstract contract RelayedAction is BaseAction {
     // Internal variable used to allow a better developer experience to reimburse tx gas cost
     uint256 private _initialGas;
 
-    // Allows relaying transactions even if there is not enough balance in the Smart Vault to pay for the tx gas cost
-    bool public isPermissiveModeActive;
-
     // Gas price limit expressed in the native token, if surpassed it wont relay the transaction
     uint256 public gasPriceLimit;
 
@@ -50,11 +47,6 @@ abstract contract RelayedAction is BaseAction {
 
     // List of allowed relayers indexed by address
     mapping (address => bool) public isRelayer;
-
-    /**
-     * @dev Emitted every time the permissive mode is changed
-     */
-    event PermissiveModeSet(bool active);
 
     /**
      * @dev Emitted every time the relayers list is changed
@@ -73,16 +65,6 @@ abstract contract RelayedAction is BaseAction {
         _initRelayedTx();
         _;
         _payRelayedTx(token);
-    }
-
-    /**
-     * @dev Sets the relayed action permissive mode. If active, it won't fail when trying to redeem gas costs to the
-     * relayer if the smart vault does not have enough balance. Sender must be authorized.
-     * @param active Whether the permissive mode should be active or not
-     */
-    function setPermissiveMode(bool active) external auth {
-        isPermissiveModeActive = active;
-        emit PermissiveModeSet(active);
     }
 
     /**

--- a/packages/base/contracts/deploy/Deployer.sol
+++ b/packages/base/contracts/deploy/Deployer.sol
@@ -115,15 +115,13 @@ library Deployer {
      * @dev Relayed action params
      * @param relayers List of addresses to be marked as allowed executors and in particular as authorized relayers
      * @param gasPriceLimit Gas price limit to be used for the relayed action
-     * @param totalCostLimit Total cost limit to be used for the relayed action
-     * @param payingGasToken Paying gas token to be used for the relayed action
+     * @param txCostLimit Total transaction cost limit to be used for the relayed action
      * @param isPermissiveModeActive Whether permissive mode is active or not
      */
     struct RelayedActionParams {
         address[] relayers;
         uint256 gasPriceLimit;
-        uint256 totalCostLimit;
-        address payingGasToken;
+        uint256 txCostLimit;
         bool isPermissiveModeActive;
         address permissiveModeAdmin;
     }
@@ -338,7 +336,7 @@ library Deployer {
 
         // Set relayed transactions limits
         action.authorize(address(this), action.setLimits.selector);
-        action.setLimits(params.gasPriceLimit, params.totalCostLimit, params.payingGasToken);
+        action.setLimits(params.gasPriceLimit, params.txCostLimit);
         action.unauthorize(address(this), action.setLimits.selector);
 
         // Set permissive mode if necessary

--- a/packages/base/contracts/deploy/Deployer.sol
+++ b/packages/base/contracts/deploy/Deployer.sol
@@ -116,14 +116,11 @@ library Deployer {
      * @param relayers List of addresses to be marked as allowed executors and in particular as authorized relayers
      * @param gasPriceLimit Gas price limit to be used for the relayed action
      * @param txCostLimit Total transaction cost limit to be used for the relayed action
-     * @param isPermissiveModeActive Whether permissive mode is active or not
      */
     struct RelayedActionParams {
         address[] relayers;
         uint256 gasPriceLimit;
         uint256 txCostLimit;
-        bool isPermissiveModeActive;
-        address permissiveModeAdmin;
     }
 
     /**
@@ -324,9 +321,6 @@ library Deployer {
         action.authorize(admin, action.setLimits.selector);
         action.authorize(admin, action.setRelayer.selector);
 
-        // Authorize permissive mode admin
-        action.authorize(params.permissiveModeAdmin, action.setPermissiveMode.selector);
-
         // Authorize relayers to call action
         action.authorize(address(this), action.setRelayer.selector);
         for (uint256 i = 0; i < params.relayers.length; i = i.uncheckedAdd(1)) {
@@ -338,13 +332,6 @@ library Deployer {
         action.authorize(address(this), action.setLimits.selector);
         action.setLimits(params.gasPriceLimit, params.txCostLimit);
         action.unauthorize(address(this), action.setLimits.selector);
-
-        // Set permissive mode if necessary
-        if (params.isPermissiveModeActive) {
-            action.authorize(address(this), action.setPermissiveMode.selector);
-            action.setPermissiveMode(true);
-            action.unauthorize(address(this), action.setPermissiveMode.selector);
-        }
     }
 
     /**

--- a/packages/base/contracts/test/actions/RelayedActionMock.sol
+++ b/packages/base/contracts/test/actions/RelayedActionMock.sol
@@ -2,16 +2,25 @@
 
 pragma solidity ^0.8.0;
 
+import '@mimic-fi/v2-helpers/contracts/utils/Denominations.sol';
+
 import '../../actions/RelayedAction.sol';
 
 contract RelayedActionMock is RelayedAction {
+    // Cost in gas of a call op + gas cost computation + withdraw form SV
     uint256 public constant override BASE_GAS = 21e3 + 20e3;
+
+    address public token;
 
     constructor(address admin, address registry) BaseAction(admin, registry) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function call() external redeemGas {
+    function setToken(address _token) external {
+        token = _token;
+    }
+
+    function call() external redeemGas(token) {
         // solhint-disable-previous-line no-empty-blocks
     }
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimic-fi/v2-smart-vaults-base",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "GPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/test/actions/RelayedAction.test.ts
+++ b/packages/base/test/actions/RelayedAction.test.ts
@@ -281,54 +281,18 @@ describe('RelayedAction', () => {
               }
             })
 
-            context('when the permissive mode is on', () => {
-              beforeEach('activate permission mode', async () => {
-                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                await action.connect(owner).setPermissiveMode(true)
-              })
-
-              itRedeemsTheGasCost()
-            })
-
-            context('when the permissive mode is off', () => {
-              beforeEach('deactivate permission mode', async () => {
-                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                await action.connect(owner).setPermissiveMode(false)
-              })
-
-              itRedeemsTheGasCost()
-            })
+            itRedeemsTheGasCost()
           })
 
           context('when the smart vault does not have enough funds', () => {
-            context('when the permissive mode is on', () => {
-              beforeEach('activate permission mode', async () => {
-                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                await action.connect(owner).setPermissiveMode(true)
-              })
-
-              itDoesNotRedeemAnyCost()
-            })
-
-            context('when the permissive mode is off', () => {
-              beforeEach('deactivate permission mode', async () => {
-                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                await action.connect(owner).setPermissiveMode(false)
-              })
-
-              it('reverts', async () => {
-                await expect(action.call()).to.be.revertedWith(
-                  native
-                    ? 'Address: insufficient balance'
-                    : token == mimic.wrappedNativeToken
-                    ? 'NOT_ENOUGH_BALANCE'
-                    : 'ERC20: transfer amount exceeds balance'
-                )
-              })
+            it('reverts', async () => {
+              await expect(action.call()).to.be.revertedWith(
+                native
+                  ? 'Address: insufficient balance'
+                  : token == mimic.wrappedNativeToken
+                  ? 'NOT_ENOUGH_BALANCE'
+                  : 'ERC20: transfer amount exceeds balance'
+              )
             })
           })
         })
@@ -358,54 +322,18 @@ describe('RelayedAction', () => {
                   }
                 })
 
-                context('when the permissive mode is on', () => {
-                  beforeEach('activate permission mode', async () => {
-                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                    await action.connect(owner).setPermissiveMode(true)
-                  })
-
-                  itRedeemsTheGasCost()
-                })
-
-                context('when the permissive mode is off', () => {
-                  beforeEach('deactivate permission mode', async () => {
-                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                    await action.connect(owner).setPermissiveMode(false)
-                  })
-
-                  itRedeemsTheGasCost()
-                })
+                itRedeemsTheGasCost()
               })
 
               context('when the smart vault does not have enough funds', () => {
-                context('when the permissive mode is on', () => {
-                  beforeEach('activate permission mode', async () => {
-                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                    await action.connect(owner).setPermissiveMode(true)
-                  })
-
-                  itDoesNotRedeemAnyCost()
-                })
-
-                context('when the permissive mode is off', () => {
-                  beforeEach('deactivate permission mode', async () => {
-                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                    await action.connect(owner).setPermissiveMode(false)
-                  })
-
-                  it('reverts', async () => {
-                    await expect(action.call()).to.be.revertedWith(
-                      native
-                        ? 'Address: insufficient balance'
-                        : token == mimic.wrappedNativeToken
-                        ? 'NOT_ENOUGH_BALANCE'
-                        : 'ERC20: transfer amount exceeds balance'
-                    )
-                  })
+                it('reverts', async () => {
+                  await expect(action.call()).to.be.revertedWith(
+                    native
+                      ? 'Address: insufficient balance'
+                      : token == mimic.wrappedNativeToken
+                      ? 'NOT_ENOUGH_BALANCE'
+                      : 'ERC20: transfer amount exceeds balance'
+                  )
                 })
               })
             })
@@ -473,19 +401,28 @@ describe('RelayedAction', () => {
       })
 
       context('when paying with another ERC20', () => {
-        const error = 1e14
-        const native = false
-        const rate = 2
-
-        beforeEach('set paying token and mock price feed', async () => {
+        beforeEach('set token', async () => {
           token = await createTokenMock()
-          const feed = await createPriceFeedMock(fp(rate))
-          const setPriceFeedRole = smartVault.interface.getSighash('setPriceFeed')
-          await smartVault.connect(owner).authorize(owner.address, setPriceFeedRole)
-          await smartVault.connect(owner).setPriceFeed(mimic.wrappedNativeToken.address, token.address, feed.address)
         })
 
-        itRedeemsGasCostProperly(error, native, rate)
+        context('when there is a price feed set', () => {
+          const error = 1e14
+          const native = false
+          const rate = 2
+
+          beforeEach('mock price feed', async () => {
+            const feed = await createPriceFeedMock(fp(rate))
+            const setPriceFeedRole = smartVault.interface.getSighash('setPriceFeed')
+            await smartVault.connect(owner).authorize(owner.address, setPriceFeedRole)
+            await smartVault.connect(owner).setPriceFeed(mimic.wrappedNativeToken.address, token.address, feed.address)
+          })
+
+          itRedeemsGasCostProperly(error, native, rate)
+        })
+
+        context('when there is no price feed set', () => {
+          itDoesNotRedeemAnyCost()
+        })
       })
     })
 

--- a/packages/base/test/actions/RelayedAction.test.ts
+++ b/packages/base/test/actions/RelayedAction.test.ts
@@ -41,62 +41,6 @@ describe('RelayedAction', () => {
     await smartVault.connect(owner).setFeeCollector(feeCollector.address)
   })
 
-  describe('setPermissiveMode', () => {
-    context('when the sender is authorized', async () => {
-      beforeEach('set sender', async () => {
-        const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-        await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-        action = action.connect(owner)
-      })
-
-      context('when the permissive mode was inactive', async () => {
-        it('can be activated', async () => {
-          const tx = await action.setPermissiveMode(true)
-
-          expect(await action.isPermissiveModeActive()).to.be.true
-          await assertEvent(tx, 'PermissiveModeSet', { active: true })
-        })
-
-        it('can be deactivated', async () => {
-          const tx = await action.setPermissiveMode(false)
-
-          expect(await action.isPermissiveModeActive()).to.be.false
-          await assertEvent(tx, 'PermissiveModeSet', { active: false })
-        })
-      })
-
-      context('when the permissive mode was active', async () => {
-        beforeEach('activate permissive mode', async () => {
-          await action.setPermissiveMode(true)
-        })
-
-        it('can be activated', async () => {
-          const tx = await action.setPermissiveMode(true)
-
-          expect(await action.isPermissiveModeActive()).to.be.true
-          await assertEvent(tx, 'PermissiveModeSet', { active: true })
-        })
-
-        it('can be deactivated', async () => {
-          const tx = await action.setPermissiveMode(false)
-
-          expect(await action.isPermissiveModeActive()).to.be.false
-          await assertEvent(tx, 'PermissiveModeSet', { active: false })
-        })
-      })
-    })
-
-    context('when the sender is not authorized', () => {
-      beforeEach('set sender', () => {
-        action = action.connect(other)
-      })
-
-      it('reverts', async () => {
-        await expect(action.setPermissiveMode(true)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
-      })
-    })
-  })
-
   describe('setRelayer', () => {
     let newRelayer: SignerWithAddress
 

--- a/packages/base/test/actions/RelayedAction.test.ts
+++ b/packages/base/test/actions/RelayedAction.test.ts
@@ -1,17 +1,16 @@
 import {
-  assertAlmostEqual,
   assertEvent,
   assertIndirectEvent,
   assertNoIndirectEvent,
   fp,
   getSigners,
+  MAX_UINT256,
   NATIVE_TOKEN_ADDRESS,
   ZERO_ADDRESS,
 } from '@mimic-fi/v2-helpers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { expect } from 'chai'
 import { Contract } from 'ethers'
-import { ethers } from 'hardhat'
 
 import { createAction, createSmartVault, createTokenMock, Mimic, setupMimic } from '../../dist'
 import { createPriceFeedMock } from '../../src/samples'
@@ -168,52 +167,37 @@ describe('RelayedAction', () => {
         action = action.connect(owner)
       })
 
-      context('when the paying gas token is not zero', async () => {
-        const payingGasToken = NATIVE_TOKEN_ADDRESS
+      context('when the limits are not zero', async () => {
+        const gasPriceLimit = 1e10
+        const txCostLimit = fp(2)
 
-        context('when the limits are not zero', async () => {
-          const gasPriceLimit = 1e10
-          const totalCostLimit = fp(2)
+        it('sets the limits', async () => {
+          await action.setLimits(gasPriceLimit, txCostLimit)
 
-          it('sets the limits', async () => {
-            await action.setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
-
-            expect(await action.gasPriceLimit()).to.be.equal(gasPriceLimit)
-            expect(await action.totalCostLimit()).to.be.equal(totalCostLimit)
-            expect(await action.payingGasToken()).to.be.equal(payingGasToken)
-          })
-
-          it('emits an event', async () => {
-            const tx = await action.setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
-            await assertEvent(tx, 'LimitsSet', { gasPriceLimit, totalCostLimit, payingGasToken })
-          })
+          expect(await action.gasPriceLimit()).to.be.equal(gasPriceLimit)
+          expect(await action.txCostLimit()).to.be.equal(txCostLimit)
         })
 
-        context('when the limits are zero', async () => {
-          const gasPriceLimit = 0
-          const totalCostLimit = 0
-          const payingGasToken = NATIVE_TOKEN_ADDRESS
-
-          it('sets the limits', async () => {
-            await action.setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
-
-            expect(await action.gasPriceLimit()).to.be.equal(gasPriceLimit)
-            expect(await action.totalCostLimit()).to.be.equal(totalCostLimit)
-            expect(await action.payingGasToken()).to.be.equal(payingGasToken)
-          })
-
-          it('emits an event', async () => {
-            const tx = await action.setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
-            await assertEvent(tx, 'LimitsSet', { gasPriceLimit, totalCostLimit, payingGasToken })
-          })
+        it('emits an event', async () => {
+          const tx = await action.setLimits(gasPriceLimit, txCostLimit)
+          await assertEvent(tx, 'LimitsSet', { gasPriceLimit, txCostLimit })
         })
       })
 
-      context('when the paying gas token is zero', async () => {
-        const payingGasToken = ZERO_ADDRESS
+      context('when the limits are zero', async () => {
+        const gasPriceLimit = 0
+        const txCostLimit = 0
 
-        it('reverts', async () => {
-          await expect(action.setLimits(0, 0, payingGasToken)).to.be.revertedWith('PAYING_GAS_TOKEN_ZERO')
+        it('sets the limits', async () => {
+          await action.setLimits(gasPriceLimit, txCostLimit)
+
+          expect(await action.gasPriceLimit()).to.be.equal(gasPriceLimit)
+          expect(await action.txCostLimit()).to.be.equal(txCostLimit)
+        })
+
+        it('emits an event', async () => {
+          const tx = await action.setLimits(gasPriceLimit, txCostLimit)
+          await assertEvent(tx, 'LimitsSet', { gasPriceLimit, txCostLimit })
         })
       })
     })
@@ -224,7 +208,7 @@ describe('RelayedAction', () => {
       })
 
       it('reverts', async () => {
-        await expect(action.setLimits(0, 0, ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(action.setLimits(0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
       })
     })
   })
@@ -237,7 +221,17 @@ describe('RelayedAction', () => {
       await action.connect(owner).authorize(owner.address, setLimitsRole)
     })
 
+    const itDoesNotRedeemAnyCost = () => {
+      it('does not redeem any cost', async () => {
+        const tx = await action.call()
+
+        await assertNoIndirectEvent(tx, smartVault.interface, 'Withdraw')
+      })
+    }
+
     context('when the sender is a relayer', () => {
+      let token: Contract
+
       beforeEach('authorize relayer', async () => {
         const setRelayerRole = action.interface.getSighash('setRelayer')
         await action.connect(owner).authorize(owner.address, setRelayerRole)
@@ -245,263 +239,258 @@ describe('RelayedAction', () => {
         action = action.connect(other)
       })
 
-      context('with gas price limit', () => {
-        const gasPriceLimit = 10e9
-        const totalCostLimit = 0
-        const payingGasToken = NATIVE_TOKEN_ADDRESS
-
-        beforeEach('setLimits', async () => {
-          await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
+      const itRedeemsGasCostProperly = (error: number, native = false, rate = 1) => {
+        beforeEach('set token', async () => {
+          await action.setToken(native ? NATIVE_TOKEN_ADDRESS : token.address)
         })
 
-        context('when the tx gas price is under the limit', () => {
-          const gasPrice = gasPriceLimit - 1
-
-          beforeEach('fund smart vault', async () => {
-            await owner.sendTransaction({ to: smartVault.address, value: fp(1) })
-          })
-
+        const itRedeemsTheGasCost = (gasPrice?: number) => {
           it('redeems the expected cost to the fee collector', async () => {
-            const tx = await action.call({ gasPrice })
+            const tx = await action.call(gasPrice ? { gasPrice } : {})
 
             const { args } = await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
-              token: payingGasToken,
+              token: native ? NATIVE_TOKEN_ADDRESS : token.address,
               recipient: feeCollector,
               data: REDEEM_GAS_NOTE,
             })
 
             const { gasUsed, effectiveGasPrice } = await tx.wait()
-            const expectedCost = gasUsed.mul(effectiveGasPrice)
-            assertAlmostEqual(args.withdrawn, expectedCost, 0.1)
+            const expectedCost = gasUsed.mul(effectiveGasPrice).mul(rate)
+            expect(args.withdrawn).to.be.at.least(expectedCost.sub(error))
+            expect(args.withdrawn).to.be.at.most(expectedCost.add(error))
+          })
+        }
+
+        context('without limits', () => {
+          const gasPriceLimit = 0
+          const txCostLimit = 0
+
+          beforeEach('set limits', async () => {
+            await action.connect(owner).setLimits(gasPriceLimit, txCostLimit)
+          })
+
+          context('when the smart vault has enough funds', () => {
+            beforeEach('fund smart vault', async () => {
+              const amount = fp(0.1).mul(rate)
+
+              if (native) await owner.sendTransaction({ to: smartVault.address, value: amount })
+              else if (token != mimic.wrappedNativeToken) await token.mint(smartVault.address, amount)
+              else {
+                await mimic.wrappedNativeToken.connect(owner).deposit({ value: amount })
+                await mimic.wrappedNativeToken.connect(owner).transfer(smartVault.address, amount)
+              }
+            })
+
+            context('when the permissive mode is on', () => {
+              beforeEach('activate permission mode', async () => {
+                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                await action.connect(owner).setPermissiveMode(true)
+              })
+
+              itRedeemsTheGasCost()
+            })
+
+            context('when the permissive mode is off', () => {
+              beforeEach('deactivate permission mode', async () => {
+                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                await action.connect(owner).setPermissiveMode(false)
+              })
+
+              itRedeemsTheGasCost()
+            })
+          })
+
+          context('when the smart vault does not have enough funds', () => {
+            context('when the permissive mode is on', () => {
+              beforeEach('activate permission mode', async () => {
+                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                await action.connect(owner).setPermissiveMode(true)
+              })
+
+              itDoesNotRedeemAnyCost()
+            })
+
+            context('when the permissive mode is off', () => {
+              beforeEach('deactivate permission mode', async () => {
+                const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                await action.connect(owner).setPermissiveMode(false)
+              })
+
+              it('reverts', async () => {
+                await expect(action.call()).to.be.revertedWith(
+                  native
+                    ? 'Address: insufficient balance'
+                    : token == mimic.wrappedNativeToken
+                    ? 'NOT_ENOUGH_BALANCE'
+                    : 'ERC20: transfer amount exceeds balance'
+                )
+              })
+            })
           })
         })
 
-        context('when the tx gas price is above the limit', () => {
-          const gasPrice = gasPriceLimit + 1
+        context('with limits', () => {
+          const gasPriceLimit = 10e9
 
-          it('reverts', async () => {
-            await expect(action.call({ gasPrice })).to.be.revertedWith('GAS_PRICE_ABOVE_LIMIT')
+          context('when the gas price is under the limit', () => {
+            const gasPrice = gasPriceLimit - 1
+
+            context('when the tx consumes less than the cost limit', () => {
+              const txCostLimit = MAX_UINT256
+
+              beforeEach('set limits', async () => {
+                await action.connect(owner).setLimits(gasPriceLimit, txCostLimit)
+              })
+
+              context('when the smart vault has enough funds', () => {
+                beforeEach('fund smart vault', async () => {
+                  const amount = fp(0.1).mul(rate)
+
+                  if (native) await owner.sendTransaction({ to: smartVault.address, value: amount })
+                  else if (token != mimic.wrappedNativeToken) await token.mint(smartVault.address, amount)
+                  else {
+                    await mimic.wrappedNativeToken.connect(owner).deposit({ value: amount })
+                    await mimic.wrappedNativeToken.connect(owner).transfer(smartVault.address, amount)
+                  }
+                })
+
+                context('when the permissive mode is on', () => {
+                  beforeEach('activate permission mode', async () => {
+                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                    await action.connect(owner).setPermissiveMode(true)
+                  })
+
+                  itRedeemsTheGasCost()
+                })
+
+                context('when the permissive mode is off', () => {
+                  beforeEach('deactivate permission mode', async () => {
+                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                    await action.connect(owner).setPermissiveMode(false)
+                  })
+
+                  itRedeemsTheGasCost()
+                })
+              })
+
+              context('when the smart vault does not have enough funds', () => {
+                context('when the permissive mode is on', () => {
+                  beforeEach('activate permission mode', async () => {
+                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                    await action.connect(owner).setPermissiveMode(true)
+                  })
+
+                  itDoesNotRedeemAnyCost()
+                })
+
+                context('when the permissive mode is off', () => {
+                  beforeEach('deactivate permission mode', async () => {
+                    const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
+                    await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
+                    await action.connect(owner).setPermissiveMode(false)
+                  })
+
+                  it('reverts', async () => {
+                    await expect(action.call()).to.be.revertedWith(
+                      native
+                        ? 'Address: insufficient balance'
+                        : token == mimic.wrappedNativeToken
+                        ? 'NOT_ENOUGH_BALANCE'
+                        : 'ERC20: transfer amount exceeds balance'
+                    )
+                  })
+                })
+              })
+            })
+
+            context('when the tx consumes more than the cost limit', () => {
+              const txCostLimit = 1
+
+              beforeEach('set limits', async () => {
+                await action.connect(owner).setLimits(gasPriceLimit, txCostLimit)
+              })
+
+              it('reverts', async () => {
+                await expect(action.call({ gasPrice })).to.be.revertedWith('TX_COST_ABOVE_LIMIT')
+              })
+            })
+          })
+
+          context('when the gas price is passes the limit', () => {
+            const gasPrice = gasPriceLimit + 1
+
+            context('when the tx consumes less than the cost limit', () => {
+              const txCostLimit = MAX_UINT256
+
+              beforeEach('set limits', async () => {
+                await action.connect(owner).setLimits(gasPriceLimit, txCostLimit)
+              })
+
+              it('reverts', async () => {
+                await expect(action.call({ gasPrice })).to.be.revertedWith('GAS_PRICE_ABOVE_LIMIT')
+              })
+            })
+
+            context('when the tx consumes more than the cost limit', () => {
+              const txCostLimit = 0
+
+              beforeEach('set limits', async () => {
+                await action.connect(owner).setLimits(gasPriceLimit, txCostLimit)
+              })
+
+              it('reverts', async () => {
+                await expect(action.call({ gasPrice })).to.be.revertedWith('GAS_PRICE_ABOVE_LIMIT')
+              })
+            })
           })
         })
+      }
+
+      context('when paying with the native token', () => {
+        const error = 1e13
+        const native = true
+
+        itRedeemsGasCostProperly(error, native)
       })
 
-      context('with total cost limit', () => {
-        let realGasCostEth
-        const gasCostError = 1e13
-        const gasPriceLimit = 0
+      context('when paying with the wrapped native token', () => {
+        const error = 1e14
+        const native = false
+        const rate = 1
 
-        beforeEach('measure real gas cost', async () => {
-          await action.connect(owner).setLimits(gasPriceLimit, fp(100), NATIVE_TOKEN_ADDRESS)
-          await owner.sendTransaction({ to: smartVault.address, value: fp(1) })
-          const { args } = await assertIndirectEvent(await action.call(), smartVault.interface, 'Withdraw')
-          realGasCostEth = args.withdrawn
+        beforeEach('set token', async () => {
+          token = mimic.wrappedNativeToken
         })
 
-        context('paying in the native token', () => {
-          const payingGasToken = NATIVE_TOKEN_ADDRESS
+        itRedeemsGasCostProperly(error, native, rate)
+      })
 
-          context('when total gas cost limit is above the actual cost', () => {
-            beforeEach('setLimits', async () => {
-              const totalCostLimit = realGasCostEth.add(gasCostError)
-              await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
-            })
+      context('when paying with another ERC20', () => {
+        const error = 1e14
+        const native = false
+        const rate = 2
 
-            context('when the smart vault has enough funds', () => {
-              beforeEach('ensure smart vault balance', async () => {
-                const balance = await ethers.provider.getBalance(smartVault.address)
-                expect(balance).to.be.gt(realGasCostEth)
-              })
-
-              context('when the permissive mode is on', () => {
-                beforeEach('activate permission mode', async () => {
-                  const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                  await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                  await action.connect(owner).setPermissiveMode(true)
-                })
-
-                it('redeems the expected cost to the fee collector', async () => {
-                  const tx = await action.call()
-
-                  const { args } = await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
-                    token: payingGasToken,
-                    recipient: feeCollector,
-                    data: REDEEM_GAS_NOTE,
-                  })
-
-                  expect(args.withdrawn).to.be.at.least(realGasCostEth.sub(gasCostError))
-                  expect(args.withdrawn).to.be.at.most(realGasCostEth.add(gasCostError))
-                })
-              })
-
-              context('when the permissive mode is off', () => {
-                beforeEach('deactivate permission mode', async () => {
-                  const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                  await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                  await action.connect(owner).setPermissiveMode(false)
-                })
-
-                it('redeems the expected cost to the fee collector', async () => {
-                  const tx = await action.call()
-
-                  const { args } = await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
-                    token: payingGasToken,
-                    recipient: feeCollector,
-                    data: REDEEM_GAS_NOTE,
-                  })
-
-                  expect(args.withdrawn).to.be.at.least(realGasCostEth.sub(gasCostError))
-                  expect(args.withdrawn).to.be.at.most(realGasCostEth.add(gasCostError))
-                })
-              })
-            })
-
-            context('when the smart vault has does not have enough funds', () => {
-              beforeEach('empty smart vault', async () => {
-                const balance = await ethers.provider.getBalance(smartVault.address)
-                const withdrawRole = smartVault.interface.getSighash('withdraw')
-                await smartVault.connect(owner).authorize(owner.address, withdrawRole)
-                await smartVault.connect(owner).withdraw(payingGasToken, balance, owner.address, '0x')
-              })
-
-              context('when the permissive mode is on', () => {
-                beforeEach('activate permission mode', async () => {
-                  const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                  await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                  await action.connect(owner).setPermissiveMode(true)
-                })
-
-                it('does not revert nor redeems any cost', async () => {
-                  const tx = await action.call()
-                  await assertNoIndirectEvent(tx, smartVault.interface, 'Withdraw')
-                })
-              })
-
-              context('when the permissive mode is off', () => {
-                beforeEach('deactivate permission mode', async () => {
-                  const setPermissiveModeRole = action.interface.getSighash('setPermissiveMode')
-                  await action.connect(owner).authorize(owner.address, setPermissiveModeRole)
-                  await action.connect(owner).setPermissiveMode(false)
-                })
-
-                it('reverts', async () => {
-                  await expect(action.call()).to.be.revertedWith('Address: insufficient balance')
-                })
-              })
-            })
-          })
-
-          context('when total gas cost limit is below the actual cost', () => {
-            beforeEach('setLimits', async () => {
-              const totalCostLimit = realGasCostEth.sub(gasCostError)
-              await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken)
-            })
-
-            it('reverts', async () => {
-              await expect(action.call()).to.be.revertedWith('TX_COST_ABOVE_LIMIT')
-            })
-          })
+        beforeEach('set paying token and mock price feed', async () => {
+          token = await createTokenMock()
+          const feed = await createPriceFeedMock(fp(rate))
+          const setPriceFeedRole = smartVault.interface.getSighash('setPriceFeed')
+          await smartVault.connect(owner).authorize(owner.address, setPriceFeedRole)
+          await smartVault.connect(owner).setPriceFeed(mimic.wrappedNativeToken.address, token.address, feed.address)
         })
 
-        context('paying in the wrapped native token', () => {
-          let payingGasToken: Contract
-
-          beforeEach('set paying token', async () => {
-            payingGasToken = mimic.wrappedNativeToken
-          })
-
-          context('when total gas cost limit is above the actual cost', () => {
-            beforeEach('setLimits', async () => {
-              const totalCostLimit = realGasCostEth.add(gasCostError)
-              await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken.address)
-            })
-
-            beforeEach('fund smart vault', async () => {
-              await mimic.wrappedNativeToken.connect(owner).deposit({ value: fp(1) })
-              await mimic.wrappedNativeToken.connect(owner).transfer(smartVault.address, fp(1))
-            })
-
-            it('redeems the expected cost to the fee collector', async () => {
-              const tx = await action.call()
-
-              const { args } = await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
-                token: payingGasToken,
-                recipient: feeCollector,
-                data: REDEEM_GAS_NOTE,
-              })
-
-              expect(args.withdrawn).to.be.at.least(realGasCostEth.sub(gasCostError))
-              expect(args.withdrawn).to.be.at.most(realGasCostEth.add(gasCostError))
-            })
-          })
-
-          context('when total gas cost limit is below the actual cost', () => {
-            beforeEach('setLimits', async () => {
-              const totalCostLimit = realGasCostEth.sub(gasCostError)
-              await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken.address)
-            })
-
-            it('reverts', async () => {
-              await expect(action.call()).to.be.revertedWith('TX_COST_ABOVE_LIMIT')
-            })
-          })
-        })
-
-        context('paying in another ERC20', () => {
-          const rate = fp(2)
-          let payingGasToken: Contract
-
-          beforeEach('set paying token and mock price feed', async () => {
-            payingGasToken = await createTokenMock()
-            const feed = await createPriceFeedMock(rate)
-            const setPriceFeedRole = smartVault.interface.getSighash('setPriceFeed')
-            await smartVault.connect(owner).authorize(owner.address, setPriceFeedRole)
-            await smartVault
-              .connect(owner)
-              .setPriceFeed(mimic.wrappedNativeToken.address, payingGasToken.address, feed.address)
-          })
-
-          context('when total gas cost limit is above the actual cost', () => {
-            beforeEach('set limits', async () => {
-              const totalCostLimit = realGasCostEth.add(gasCostError).mul(rate).div(fp(1))
-              await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken.address)
-            })
-
-            beforeEach('fund smart vault', async () => {
-              await payingGasToken.mint(smartVault.address, fp(2))
-            })
-
-            it('redeems the expected cost to the fee collector', async () => {
-              const tx = await action.call()
-
-              const { args } = await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
-                token: payingGasToken,
-                recipient: feeCollector,
-                data: REDEEM_GAS_NOTE,
-              })
-
-              expect(args.withdrawn).to.be.at.least(realGasCostEth.sub(gasCostError).mul(rate).div(fp(1)))
-              expect(args.withdrawn).to.be.at.most(realGasCostEth.add(gasCostError).mul(rate).div(fp(1)))
-            })
-          })
-
-          context('when total gas cost limit is below the actual cost', () => {
-            beforeEach('setLimits', async () => {
-              const totalCostLimit = realGasCostEth.sub(gasCostError).mul(rate).div(fp(1))
-              await action.connect(owner).setLimits(gasPriceLimit, totalCostLimit, payingGasToken.address)
-            })
-
-            it('reverts', async () => {
-              await expect(action.call()).to.be.revertedWith('TX_COST_ABOVE_LIMIT')
-            })
-          })
-        })
+        itRedeemsGasCostProperly(error, native, rate)
       })
     })
 
     context('when the sender is not a relayer', () => {
-      it('reverts', async () => {
-        await expect(action.call()).to.be.revertedWith('SENDER_NOT_RELAYER')
-      })
+      itDoesNotRedeemAnyCost()
     })
   })
 })

--- a/packages/base/test/deploy/Deployer.test.ts
+++ b/packages/base/test/deploy/Deployer.test.ts
@@ -49,8 +49,7 @@ describe('Deployer', () => {
       relayedActionParams: {
         relayers: [randomAddress(), randomAddress()],
         gasPriceLimit: 100e9,
-        totalCostLimit: fp(100),
-        payingGasToken: randomAddress(),
+        txCostLimit: fp(100),
         permissiveModeAdmin: randomAddress(),
         isPermissiveModeActive: false,
       },
@@ -255,8 +254,7 @@ describe('Deployer', () => {
 
     it('sets the expected gas limits', async () => {
       expect(await relayed.gasPriceLimit()).to.be.equal(config.relayedActionParams.relayedActionParams.gasPriceLimit)
-      expect(await relayed.totalCostLimit()).to.be.equal(config.relayedActionParams.relayedActionParams.totalCostLimit)
-      expect(await relayed.payingGasToken()).to.be.equal(config.relayedActionParams.relayedActionParams.payingGasToken)
+      expect(await relayed.txCostLimit()).to.be.equal(config.relayedActionParams.relayedActionParams.txCostLimit)
     })
 
     it('sets the expected permissive mode', async () => {

--- a/packages/base/test/deploy/Deployer.test.ts
+++ b/packages/base/test/deploy/Deployer.test.ts
@@ -50,8 +50,6 @@ describe('Deployer', () => {
         relayers: [randomAddress(), randomAddress()],
         gasPriceLimit: 100e9,
         txCostLimit: fp(100),
-        permissiveModeAdmin: randomAddress(),
-        isPermissiveModeActive: false,
       },
     },
     timeLockedActionParams: {
@@ -255,12 +253,6 @@ describe('Deployer', () => {
     it('sets the expected gas limits', async () => {
       expect(await relayed.gasPriceLimit()).to.be.equal(config.relayedActionParams.relayedActionParams.gasPriceLimit)
       expect(await relayed.txCostLimit()).to.be.equal(config.relayedActionParams.relayedActionParams.txCostLimit)
-    })
-
-    it('sets the expected permissive mode', async () => {
-      expect(await relayed.isPermissiveModeActive()).to.be.equal(
-        config.relayedActionParams.relayedActionParams.isPermissiveModeActive
-      )
     })
 
     it('allows the requested relayers', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,6 +1022,20 @@
     "@mimic-fi/v2-swap-connector" "0.0.15"
     "@openzeppelin/contracts" "4.7.0"
 
+"@mimic-fi/v2-smart-vaults-base@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@mimic-fi/v2-smart-vaults-base/-/v2-smart-vaults-base-0.0.5.tgz#53a09bb47d2e45fddb691d0ed77d225490b4836f"
+  integrity sha512-CxSW2ytUL/SZbIgIRs8iHnwDm/Yw/YBQJirfkA7dpf4JLaGO76olUkJRRXVhjNZ3Mo7UzT7bA0WMlPywZLZlyQ==
+  dependencies:
+    "@mimic-fi/v2-bridge-connector" "0.1.0"
+    "@mimic-fi/v2-helpers" "0.1.1"
+    "@mimic-fi/v2-price-oracle" "0.1.0"
+    "@mimic-fi/v2-registry" "0.1.0"
+    "@mimic-fi/v2-smart-vault" "0.1.0"
+    "@mimic-fi/v2-strategies" "0.1.0"
+    "@mimic-fi/v2-swap-connector" "0.1.0"
+    "@openzeppelin/contracts" "4.7.0"
+
 "@mimic-fi/v2-strategies@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@mimic-fi/v2-strategies/-/v2-strategies-0.0.6.tgz#1cb142922d86e3cfaa4a7d994ca08d8ab2916bf0"


### PR DESCRIPTION
The main idea behind this change is to start making sure actions can pay gas costs by themselves instead of trusting there is enough money to do it in the vault itself.

This PR includes:
- Parameterize paying gas tokens and drop it from the limits configuration 
- Turn `totalGasCost` to be `txGasCost` expressed always in the native token
- Avoid redeeming gas cost if fetching native token price fails (missing feed)
- Allow passing a native token price from outside if desired
- Drop permissive mode
