### PR TITLE
Base: Implement token threshold config

### DIFF
--- a/packages/base/contracts/config/TokensThreshold.sol
+++ b/packages/base/contracts/config/TokensThreshold.sol
@@ -281,7 +281,7 @@ library TokensThreshold {
     }
 
     /**
-     * @dev Tells if a token and amount are compliant with a threshold, returns false if the threshold is not set
+     * @dev Tells if a token and amount are compliant with a threshold, returns true if the threshold is not set
      * @param threshold Threshold to be evaluated
      * @param token Address of the token to be validated
      * @param amount Token amount to be validated
@@ -293,7 +293,7 @@ library TokensThreshold {
         uint256 amount,
         function(address, address) internal view returns (uint256) getPrice
     ) internal view returns (bool) {
-        if (threshold.token == address(0)) return false;
+        if (threshold.token == address(0)) return true;
         uint256 price = token == threshold.token ? FixedPoint.ONE : getPrice(token, threshold.token);
         uint256 convertedAmount = amount.mulDown(price);
         return convertedAmount >= threshold.min && (threshold.max == 0 || convertedAmount <= threshold.max);

--- a/packages/base/contracts/config/TokensThreshold.sol
+++ b/packages/base/contracts/config/TokensThreshold.sol
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.3;
+
+import '@mimic-fi/v2-helpers/contracts/math/FixedPoint.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+/**
+ * @dev Library to operate tokens threshold configs.
+ * Token threshold configs can be used to tell if a specific token amount is compliant with certain minimum or maximum
+ * values. These values can be defined in foreign tokens in which case a price function must be used to compute rates.
+ * Additionally, token threshold configs make use of a default threshold config as a fallback in case there is no
+ * custom threshold defined for the token being evaluated.
+ */
+library TokensThreshold {
+    using FixedPoint for uint256;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /**
+     * @dev Threshold defined by a token address and min/max values
+     */
+    struct Threshold {
+        address token;
+        uint256 min;
+        uint256 max;
+    }
+
+    /**
+     * @dev Threshold config defined by a default config and an enumerable map of custom thresholds per token
+     */
+    struct Config {
+        Threshold defaultThreshold;
+        TokenToThresholdMap tokensThresholds;
+    }
+
+    /**
+     * @dev Reverts if the requested token and amount does not comply with the given threshold config
+     * @param self Token threshold config to be evaluated
+     * @param token Address of the token to be validated
+     * @param amount Token amount to be validated
+     * @param getPrice Function to be used in order to rate the requested token with the threshold to be evaluated
+     */
+    function validate(
+        Config storage self,
+        address token,
+        uint256 amount,
+        function(address, address) internal view returns (uint256) getPrice
+    ) internal view {
+        require(isValid(self, token, amount, getPrice), 'TOKEN_THRESHOLD_FORBIDDEN');
+    }
+
+    /**
+     * @dev Tells if a token and amount are compliant with a threshold config.
+     * @param self Threshold config to be evaluated
+     * @param token Address of the token to be validated
+     * @param amount Token amount to be validated
+     * @param getPrice Function to be used in order to rate the requested token with the threshold to be evaluated
+     */
+    function isValid(
+        Config storage self,
+        address token,
+        uint256 amount,
+        function(address, address) internal view returns (uint256) getPrice
+    ) internal view returns (bool) {
+        return isValid(getThreshold(self, token), token, amount, getPrice);
+    }
+
+    /**
+     * @dev Tells the threshold token applied for a given token. If there is a custom threshold set for the given token,
+     * it will be prioritized over the default one. Otherwise, the default threshold is used.
+     * @param self Threshold config being queried
+     * @param token Address of the token being queried
+     */
+    function getThreshold(Config storage self, address token) internal view returns (Threshold memory) {
+        (bool exists, Threshold memory threshold) = tryGet(self.tokensThresholds, token);
+        return exists ? threshold : self.defaultThreshold;
+    }
+
+    /**
+     * @dev Tells the default threshold for a config
+     * @param self Threshold config being queried
+     */
+    function getDefault(Config storage self) internal view returns (Threshold memory) {
+        return self.defaultThreshold;
+    }
+
+    /**
+     * @dev Tells the list of custom thresholds set for a config
+     * @param self Threshold config being queried
+     */
+    function getThresholds(Config storage self) internal view returns (address[] memory, Threshold[] memory) {
+        return getPairs(self.tokensThresholds);
+    }
+
+    /**
+     * @dev Sets a new default threshold config
+     * @param self Threshold config to be updated
+     * @param threshold Threshold config to be set as the default one. Threshold token cannot be zero and max amount
+     * must be greater than or equal to the min amount, with the exception of max being set to zero in which case it
+     * will be ignored.
+     */
+    function setDefault(Config storage self, Threshold memory threshold) internal {
+        validate(threshold);
+        self.defaultThreshold = threshold;
+    }
+
+    /**
+     * @dev Drops a custom threshold set for a given token, ignored if there was no custom threshold set for the token
+     * @param self Threshold config to be updated
+     * @param token Address of the token whose custom threshold will be unset
+     */
+    function remove(Config storage self, address token) internal returns (bool) {
+        return remove(self.tokensThresholds, token);
+    }
+
+    /**
+     * @dev Sets a new threshold config for a given token
+     * @param self Threshold config to be updated
+     * @param token Address of the token to be set with a custom threshold config
+     * @param threshold Threshold config to be set
+     * @return True if the threshold was set, that is if it was not already present
+     */
+    function set(Config storage self, address token, Threshold memory threshold) internal returns (bool) {
+        return set(self.tokensThresholds, token, threshold);
+    }
+
+    /**
+     * @dev Sets a bunch threshold configs for a list of tokens
+     * @param self Threshold config to be updated
+     * @param tokens List of addresses of the tokens to be set with a custom threshold config
+     * @param thresholds List of threshold configs to be set for each token
+     */
+    function set(Config storage self, address[] memory tokens, Threshold[] memory thresholds) internal {
+        clean(self.tokensThresholds);
+        set(self.tokensThresholds, tokens, thresholds);
+    }
+
+    ////////////////////////////////////////
+    // Enumerable map for token threshold //
+    ////////////////////////////////////////
+
+    /**
+     * @dev Enumerable map of tokens to threshold configs
+     */
+    struct TokenToThresholdMap {
+        EnumerableSet.AddressSet _tokens;
+        mapping (address => Threshold) _thresholds;
+    }
+
+    /**
+     * @dev Returns the number of thresholds set in the map. O(1).
+     */
+    function length(TokenToThresholdMap storage map) private view returns (uint256) {
+        return map._tokens.length();
+    }
+
+    /**
+     * @dev Returns true if there is a threshold set for the requested token address. O(1).
+     */
+    function contains(TokenToThresholdMap storage map, address token) private view returns (bool) {
+        return map._tokens.contains(token);
+    }
+
+    /**
+     * @dev Returns the token-threshold pair stored at position `i` in the map. Note that there are no guarantees on
+     * the ordering of entries inside the array, and it may change when more entries are added or removed. O(1).
+     * @param i Index to be accessed in the enumerable map, must be strictly less than its length
+     */
+    function at(TokenToThresholdMap storage map, uint256 i) private view returns (address, Threshold memory) {
+        address token = map._tokens.at(i);
+        return (token, map._thresholds[token]);
+    }
+
+    /**
+     * @dev Returns the threshold associated with `token`. Reverts if there is no threshold set. O(1).
+     */
+    function get(TokenToThresholdMap storage map, address token) private view returns (Threshold memory) {
+        Threshold memory threshold = map._thresholds[token];
+        require(threshold.token != address(0) || contains(map, token), 'MISSING_TOKEN_THRESHOLD');
+        return threshold;
+    }
+
+    /**
+     * @dev Tries to returns the threshold associated with `token`. Does not revert if there is no threshold set. O(1).
+     */
+    function tryGet(TokenToThresholdMap storage map, address token) private view returns (bool, Threshold memory) {
+        Threshold memory threshold = map._thresholds[token];
+        return (contains(map, token), threshold);
+    }
+
+    /**
+     * @dev Returns the list of tokens that have a threshold config set. O(N)
+     */
+    function getTokens(TokenToThresholdMap storage map) private view returns (address[] memory tokens) {
+        tokens = new address[](length(map));
+        for (uint256 i = 0; i < tokens.length; i++) {
+            (address token, ) = at(map, i);
+            tokens[i] = token;
+        }
+    }
+
+    /**
+     * @dev Returns the list of thresholds. O(N)
+     */
+    function getThresholds(TokenToThresholdMap storage map) private view returns (Threshold[] memory thresholds) {
+        thresholds = new Threshold[](length(map));
+        for (uint256 i = 0; i < thresholds.length; i++) {
+            (, Threshold memory threshold) = at(map, i);
+            thresholds[i] = threshold;
+        }
+    }
+
+    /**
+     * @dev Returns the list of token-threshold pairs. O(N)
+     */
+    function getPairs(TokenToThresholdMap storage map)
+        private
+        view
+        returns (address[] memory tokens, Threshold[] memory thresholds)
+    {
+        tokens = new address[](length(map));
+        thresholds = new Threshold[](tokens.length);
+        for (uint256 i = 0; i < thresholds.length; i++) {
+            (address token, Threshold memory threshold) = at(map, i);
+            tokens[i] = token;
+            thresholds[i] = threshold;
+        }
+    }
+
+    /**
+     * @dev Removes all the thresholds set in a map. O(N).
+     */
+    function clean(TokenToThresholdMap storage map) private {
+        address[] memory tokens = getTokens(map);
+        for (uint256 i = 0; i < tokens.length; i++) remove(map, tokens[i]);
+    }
+
+    /**
+     * @dev Removes a threshold for a token. O(1).
+     * @return True if the threshold was removed from the map, that is if it was present.
+     */
+    function remove(TokenToThresholdMap storage map, address token) private returns (bool) {
+        delete map._thresholds[token];
+        return map._tokens.remove(token);
+    }
+
+    /**
+     * @dev Sets a bunch of thresholds for a list of tokens. O(1).
+     * @param tokens List of addresses of the tokens to be set with a threshold.
+     * @param thresholds List of threshold to be set for each token. Length must be equal to the list of tokens.
+     * Threshold token cannot be zero and max amount must be greater than or equal to the min amount, with the
+     * exception of max being set to zero in which case it will be ignored.
+     */
+    function set(TokenToThresholdMap storage map, address[] memory tokens, Threshold[] memory thresholds) private {
+        require(tokens.length == thresholds.length, 'TOKENS_THRESHOLD_BAD_INPUT_LEN');
+        for (uint256 i = 0; i < tokens.length; i++) set(map, tokens[i], thresholds[i]);
+    }
+
+    /**
+     * @dev Sets a threshold for a token. O(1).
+     * @param token Address of the token to be set, cannot be zero
+     * @param threshold Threshold to be set. Threshold token cannot be zero and max amount must be greater than
+     * or equal to the min amount, with the exception of max being set to zero in which case it will be ignored.
+     * @return True if the threshold was added to the map, that is if it was not already present.
+     */
+    function set(TokenToThresholdMap storage map, address token, Threshold memory threshold) private returns (bool) {
+        require(token != address(0), 'THRESHOLD_TOKEN_ADDRESS_ZERO');
+        validate(threshold);
+
+        map._thresholds[token] = threshold;
+        return map._tokens.add(token);
+    }
+
+    /**
+     * @dev Reverts if a threshold is not considered valid, that is if the token is zero or if the max amount is greater
+     * than zero but lower than the min amount.
+     */
+    function validate(Threshold memory threshold) private pure {
+        require(threshold.token != address(0), 'INVALID_THRESHOLD_TOKEN_ZERO');
+        require(threshold.max == 0 || threshold.max >= threshold.min, 'INVALID_THRESHOLD_MAX_LT_MIN');
+    }
+
+    /**
+     * @dev Tells if a token and amount are compliant with a threshold, returns false if the threshold is not set
+     * @param threshold Threshold to be evaluated
+     * @param token Address of the token to be validated
+     * @param amount Token amount to be validated
+     * @param getPrice Function to be used in order to rate the requested token with the threshold to be evaluated
+     */
+    function isValid(
+        Threshold memory threshold,
+        address token,
+        uint256 amount,
+        function(address, address) internal view returns (uint256) getPrice
+    ) internal view returns (bool) {
+        if (threshold.token == address(0)) return false;
+        uint256 price = token == threshold.token ? FixedPoint.ONE : getPrice(token, threshold.token);
+        uint256 convertedAmount = amount.mulDown(price);
+        return convertedAmount >= threshold.min && (threshold.max == 0 || convertedAmount <= threshold.max);
+    }
+}

--- a/packages/base/contracts/test/config/TokensThresholdMock.sol
+++ b/packages/base/contracts/test/config/TokensThresholdMock.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.3;
+
+import '../../config/TokensThreshold.sol';
+
+contract TokensThresholdMock {
+    using TokensThreshold for TokensThreshold.Config;
+
+    TokensThreshold.Config internal tokensThreshold;
+    mapping (address => mapping (address => uint256)) internal rates;
+
+    function mockRate(address base, address quote, uint256 rate) external {
+        rates[base][quote] = rate;
+    }
+
+    function getRate(address base, address quote) internal view returns (uint256) {
+        uint256 rate = rates[base][quote];
+        require(rate > 0, 'TOKENS_THRESHOLD_MOCK_RATE_ZERO');
+        return rate;
+    }
+
+    function validate(address token, uint256 amount) external view {
+        tokensThreshold.validate(token, amount, getRate);
+    }
+
+    function isValid(address token, uint256 amount) external view returns (bool) {
+        return tokensThreshold.isValid(token, amount, getRate);
+    }
+
+    function getThreshold(address token) external view returns (TokensThreshold.Threshold memory) {
+        return tokensThreshold.getThreshold(token);
+    }
+
+    function getDefault() external view returns (TokensThreshold.Threshold memory) {
+        return tokensThreshold.getDefault();
+    }
+
+    function getThresholds()
+        external
+        view
+        returns (address[] memory tokens, TokensThreshold.Threshold[] memory thresholds)
+    {
+        return tokensThreshold.getThresholds();
+    }
+
+    function setDefault(TokensThreshold.Threshold memory threshold) external {
+        tokensThreshold.setDefault(threshold);
+    }
+
+    function removeThreshold(address token) external returns (bool) {
+        return tokensThreshold.remove(token);
+    }
+
+    function setThreshold(address token, TokensThreshold.Threshold memory threshold) external returns (bool) {
+        return tokensThreshold.set(token, threshold);
+    }
+
+    function setManyThresholds(address[] memory tokens, TokensThreshold.Threshold[] memory thresholds) external {
+        return tokensThreshold.set(tokens, thresholds);
+    }
+}

--- a/packages/base/test/config/TokensThreshold.test.ts
+++ b/packages/base/test/config/TokensThreshold.test.ts
@@ -249,15 +249,15 @@ describe('TokensThreshold', () => {
 
     context('when there is no default threshold set', () => {
       context('when there are no custom thresholds set', () => {
-        it('rejects any combination', async () => {
-          await assertInvalid(WETH, fp(0))
-          await assertInvalid(WETH, fp(1000))
+        it('allows any combination', async () => {
+          await assertValid(WETH, fp(0))
+          await assertValid(WETH, fp(1000))
 
-          await assertInvalid(USDC, fp(0))
-          await assertInvalid(USDC, fp(1000))
+          await assertValid(USDC, fp(0))
+          await assertValid(USDC, fp(1000))
 
-          await assertInvalid(ZERO_ADDRESS, fp(0))
-          await assertInvalid(ZERO_ADDRESS, fp(1000))
+          await assertValid(ZERO_ADDRESS, fp(0))
+          await assertValid(ZERO_ADDRESS, fp(1000))
         })
       })
 
@@ -268,6 +268,7 @@ describe('TokensThreshold', () => {
         })
 
         it('applies only for when the requested token matches', async () => {
+          // Applies the default threshold for WETH
           await assertInvalid(WETH, fp(0))
           await assertInvalid(WETH, fp(1))
           await assertValid(WETH, fp(2))
@@ -276,11 +277,13 @@ describe('TokensThreshold', () => {
           await assertInvalid(WETH, fp(5))
           await assertInvalid(WETH, fp(100))
 
-          await assertInvalid(USDC, fp(0))
-          await assertInvalid(USDC, fp(1000))
+          // No threshold set
+          await assertValid(USDC, fp(0))
+          await assertValid(USDC, fp(1000))
 
-          await assertInvalid(ZERO_ADDRESS, fp(0))
-          await assertInvalid(ZERO_ADDRESS, fp(1000))
+          // No threshold set
+          await assertValid(ZERO_ADDRESS, fp(0))
+          await assertValid(ZERO_ADDRESS, fp(1000))
         })
       })
     })

--- a/packages/base/test/config/TokensThreshold.test.ts
+++ b/packages/base/test/config/TokensThreshold.test.ts
@@ -1,0 +1,347 @@
+import { BigNumberish, deploy, fp, ZERO_ADDRESS } from '@mimic-fi/v2-helpers'
+import { expect } from 'chai'
+import { Contract } from 'ethers'
+
+/* eslint-disable no-secrets/no-secrets */
+
+describe('TokensThreshold', () => {
+  let config: Contract
+
+  const tokenA = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+  const tokenB = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+  const tokenC = '0xf584F8728B874a6a5c7A8d4d387C9aae9172D621'
+
+  beforeEach('deploy threshold config', async () => {
+    config = await deploy('TokensThresholdMock')
+  })
+
+  describe('set default', () => {
+    const itCanBeSet = (token: string, min: BigNumberish, max: BigNumberish) => {
+      it('sets the default correctly', async () => {
+        await config.setDefault({ token, min, max })
+
+        const threshold = await config.getDefault()
+        expect(threshold.token).to.be.equal(token)
+        expect(threshold.min).to.be.equal(min)
+        expect(threshold.max).to.be.equal(max)
+      })
+    }
+
+    context('when the token is not zero', () => {
+      const token = tokenA
+
+      context('when the maximum amount is zero', () => {
+        const max = fp(0)
+
+        context('when the minimum amount is zero', () => {
+          const min = fp(0)
+
+          itCanBeSet(token, min, max)
+        })
+
+        context('when the minimum amount is not zero', () => {
+          const min = fp(2)
+
+          itCanBeSet(token, min, max)
+        })
+      })
+
+      context('when the maximum amount is not zero', () => {
+        const max = fp(2)
+
+        context('when the minimum amount is zero', () => {
+          const min = 0
+
+          itCanBeSet(token, min, max)
+        })
+
+        context('when the minimum amount is not zero', () => {
+          context('when the minimum amount is lower than the maximum amount', () => {
+            const min = max.sub(1)
+
+            itCanBeSet(token, min, max)
+          })
+
+          context('when the minimum amount is equal to the maximum amount', () => {
+            const min = max
+
+            itCanBeSet(token, min, max)
+          })
+
+          context('when the minimum amount is greater than the maximum amount', () => {
+            const min = max.add(1)
+
+            it('reverts', async () => {
+              await expect(config.setDefault({ token, min, max })).to.be.revertedWith('INVALID_THRESHOLD_MAX_LT_MIN')
+            })
+          })
+        })
+      })
+    })
+
+    context('when the token is zero', () => {
+      const token = ZERO_ADDRESS
+
+      it('reverts', async () => {
+        await expect(config.setDefault({ token, min: 0, max: 0 })).to.be.revertedWith('INVALID_THRESHOLD_TOKEN_ZERO')
+      })
+    })
+  })
+
+  describe('set custom', () => {
+    const itCanBeSet = (token: string, thresholdToken: string, min: BigNumberish, max: BigNumberish) => {
+      it('sets the custom threshold correctly', async () => {
+        await config.setThreshold(token, { token: thresholdToken, min, max })
+
+        const threshold = await config.getThreshold(token)
+        expect(threshold.token).to.be.equal(thresholdToken)
+        expect(threshold.min).to.be.equal(min)
+        expect(threshold.max).to.be.equal(max)
+
+        const { tokens, thresholds } = await config.getThresholds()
+
+        expect(tokens).to.have.lengthOf(1)
+        expect(tokens[0]).to.be.equal(token)
+
+        expect(thresholds).to.have.lengthOf(1)
+        expect(thresholds[0].token).to.be.equal(thresholdToken)
+        expect(thresholds[0].min).to.be.equal(min)
+        expect(thresholds[0].max).to.be.equal(max)
+      })
+    }
+
+    context('when the token is not zero', () => {
+      const token = tokenA
+
+      context('when the threshold token is not zero', () => {
+        const thresholdToken = tokenB
+
+        context('when the maximum amount is zero', () => {
+          const max = fp(0)
+
+          context('when the minimum amount is zero', () => {
+            const min = fp(0)
+
+            itCanBeSet(token, thresholdToken, min, max)
+          })
+
+          context('when the minimum amount is not zero', () => {
+            const min = fp(2)
+
+            itCanBeSet(token, thresholdToken, min, max)
+          })
+        })
+
+        context('when the maximum amount is not zero', () => {
+          const max = fp(2)
+
+          context('when the minimum amount is zero', () => {
+            const min = 0
+
+            itCanBeSet(token, thresholdToken, min, max)
+          })
+
+          context('when the minimum amount is not zero', () => {
+            context('when the minimum amount is lower than the maximum amount', () => {
+              const min = max.sub(1)
+
+              itCanBeSet(token, thresholdToken, min, max)
+            })
+
+            context('when the minimum amount is equal to the maximum amount', () => {
+              const min = max
+
+              itCanBeSet(token, thresholdToken, min, max)
+            })
+
+            context('when the minimum amount is greater than the maximum amount', () => {
+              const min = max.add(1)
+
+              it('reverts', async () => {
+                await expect(config.setThreshold(token, { token: thresholdToken, min, max })).to.be.revertedWith(
+                  'INVALID_THRESHOLD_MAX_LT_MIN'
+                )
+              })
+            })
+          })
+        })
+      })
+
+      context('when the threshold token is zero', () => {
+        const thresholdToken = ZERO_ADDRESS
+
+        it('reverts', async () => {
+          await expect(config.setThreshold(token, { token: thresholdToken, min: 0, max: 0 })).to.be.revertedWith(
+            'INVALID_THRESHOLD_TOKEN_ZERO'
+          )
+        })
+      })
+    })
+
+    context('when the token is zero', () => {
+      const token = ZERO_ADDRESS
+
+      it('reverts', async () => {
+        await expect(config.setThreshold(token, { token: ZERO_ADDRESS, min: 0, max: 0 })).to.be.revertedWith(
+          'THRESHOLD_TOKEN_ADDRESS_ZERO'
+        )
+      })
+    })
+  })
+
+  describe('remove', () => {
+    const tokens = [tokenA, tokenB]
+    const thresholds = [
+      { token: tokenC, min: 1, max: 2 },
+      { token: tokenC, min: 3, max: 5 },
+    ]
+
+    beforeEach('set some thresholds', async () => {
+      await config.setManyThresholds(tokens, thresholds)
+    })
+
+    context('when there was a custom threshold set', () => {
+      const token = tokenA
+
+      it('removes it from the list', async () => {
+        await config.removeThreshold(token)
+
+        const { tokens, thresholds } = await config.getThresholds()
+
+        expect(tokens).to.have.lengthOf(1)
+        expect(tokens[0]).to.be.equal(tokenB)
+
+        expect(thresholds).to.have.lengthOf(1)
+        expect(thresholds[0].token).to.be.equal(tokenC)
+        expect(thresholds[0].min).to.be.equal(3)
+        expect(thresholds[0].max).to.be.equal(5)
+      })
+    })
+
+    context('when there was no custom threshold set', () => {
+      const token = tokenC
+
+      it('does not affect the list', async () => {
+        await config.removeThreshold(token)
+
+        const { tokens, thresholds } = await config.getThresholds()
+        expect(tokens).to.have.lengthOf(tokens.length)
+        expect(tokens).to.have.members(tokens)
+        expect(thresholds).to.have.members(thresholds)
+      })
+    })
+  })
+
+  describe('validate', () => {
+    const USDC = tokenA
+    const USDT = tokenB
+    const WETH = tokenC
+
+    const assertValid = async (token: string, amount: BigNumberish) => {
+      expect(await config.isValid(token, amount)).to.be.true
+      await expect(config.validate(token, amount)).not.to.be.reverted
+    }
+
+    const assertInvalid = async (token: string, amount: BigNumberish) => {
+      expect(await config.isValid(token, amount)).to.be.false
+      await expect(config.validate(token, amount)).to.be.revertedWith('TOKEN_THRESHOLD_FORBIDDEN')
+    }
+
+    context('when there is no default threshold set', () => {
+      context('when there are no custom thresholds set', () => {
+        it('rejects any combination', async () => {
+          await assertInvalid(WETH, fp(0))
+          await assertInvalid(WETH, fp(1000))
+
+          await assertInvalid(USDC, fp(0))
+          await assertInvalid(USDC, fp(1000))
+
+          await assertInvalid(ZERO_ADDRESS, fp(0))
+          await assertInvalid(ZERO_ADDRESS, fp(1000))
+        })
+      })
+
+      context('when there is a custom threshold set', () => {
+        beforeEach('set threshold', async () => {
+          await config.mockRate(WETH, USDT, fp(1600))
+          await config.setThreshold(WETH, { token: USDT, min: fp(3200), max: fp(6400) })
+        })
+
+        it('applies only for when the requested token matches', async () => {
+          await assertInvalid(WETH, fp(0))
+          await assertInvalid(WETH, fp(1))
+          await assertValid(WETH, fp(2))
+          await assertValid(WETH, fp(3))
+          await assertValid(WETH, fp(4))
+          await assertInvalid(WETH, fp(5))
+          await assertInvalid(WETH, fp(100))
+
+          await assertInvalid(USDC, fp(0))
+          await assertInvalid(USDC, fp(1000))
+
+          await assertInvalid(ZERO_ADDRESS, fp(0))
+          await assertInvalid(ZERO_ADDRESS, fp(1000))
+        })
+      })
+    })
+
+    context('when there is a default threshold set', () => {
+      beforeEach('set default', async () => {
+        await config.mockRate(WETH, USDC, fp(1600))
+        await config.setDefault({ token: USDC, min: fp(400), max: fp(800) })
+      })
+
+      context('when there are no custom thresholds set', () => {
+        it('applies the default threshold', async () => {
+          // Applies the default threshold for WETH
+          await assertInvalid(WETH, fp(0))
+          await assertValid(WETH, fp(0.25))
+          await assertValid(WETH, fp(0.5))
+          await assertInvalid(WETH, fp(1))
+
+          // Applies the default threshold for USDC
+          await assertInvalid(USDC, fp(0))
+          await assertInvalid(USDC, fp(300))
+          await assertValid(USDC, fp(400))
+          await assertValid(USDC, fp(600))
+          await assertValid(USDC, fp(800))
+          await assertInvalid(USDC, fp(1000))
+
+          // It tries to fetch a rate since it tries to use the default threshold
+          await expect(config.validate(USDT, fp(0))).to.be.revertedWith('TOKENS_THRESHOLD_MOCK_RATE_ZERO')
+          await expect(config.validate(ZERO_ADDRESS, fp(0))).to.be.revertedWith('TOKENS_THRESHOLD_MOCK_RATE_ZERO')
+        })
+      })
+
+      context('when there is a custom threshold set', () => {
+        beforeEach('set threshold', async () => {
+          await config.mockRate(WETH, USDT, fp(1650))
+          await config.setThreshold(WETH, { token: USDT, min: fp(3300), max: fp(6600) })
+        })
+
+        it('applies the custom threshold only when the requested token matches', async () => {
+          // Applies the custom threshold for WETH
+          await assertInvalid(WETH, fp(0))
+          await assertInvalid(WETH, fp(1))
+          await assertValid(WETH, fp(2))
+          await assertValid(WETH, fp(3))
+          await assertValid(WETH, fp(4))
+          await assertInvalid(WETH, fp(5))
+          await assertInvalid(WETH, fp(100))
+
+          // Applies the default threshold for USDC
+          await assertInvalid(USDC, fp(0))
+          await assertInvalid(USDC, fp(300))
+          await assertValid(USDC, fp(400))
+          await assertValid(USDC, fp(600))
+          await assertValid(USDC, fp(800))
+          await assertInvalid(USDC, fp(1000))
+
+          // It tries to fetch a rate since it tries to use the default threshold
+          await expect(config.validate(USDT, fp(0))).to.be.revertedWith('TOKENS_THRESHOLD_MOCK_RATE_ZERO')
+          await expect(config.validate(ZERO_ADDRESS, fp(0))).to.be.revertedWith('TOKENS_THRESHOLD_MOCK_RATE_ZERO')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Threshold config that allows validating a token-amount pair. Thresholds are expressed in a second token (it could be the same one), a minimum and a maximum value. It's also possible to define a default threshold that will be applied for all token-amount pairs unless a custom one is defined.