### PR TITLE
Base: Model time lock config

### DIFF
--- a/packages/base/contracts/config/TimeLock.sol
+++ b/packages/base/contracts/config/TimeLock.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.3;
+
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+/**
+ * @dev Library to operate time-lock configs.
+ * It allows users to make sure a certain period of time has passed between two bumps.
+ */
+library TimeLock {
+    /**
+     * @dev Time lock config
+     * @param delay Period in seconds that must be waited between two bumps
+     * @param nextResetTime Future timestamp in which the config can be bumped again
+     */
+    struct Config {
+        uint256 delay;
+        uint256 nextResetTime;
+    }
+
+    /**
+     * @dev Reverts if the given time-lock is not expired, otherwise it bumps it based on its delay
+     * @param self Time-lock config to be evaluated
+     */
+    function validate(Config storage self) internal {
+        require(isValid(self), 'TIME_LOCK_FORBIDDEN');
+        if (isSet(self)) self.nextResetTime = block.timestamp + self.delay;
+    }
+
+    /**
+     * @dev Tells if a time-lock is expired or not, it must be set to be considered expired
+     * @param self Time-lock config to be checked
+     */
+    function isValid(Config storage self) internal view returns (bool) {
+        return !isSet(self) || block.timestamp >= self.nextResetTime;
+    }
+
+    /**
+     * @dev Tells if a time-lock is set
+     * @param self Time-lock config to be checked
+     */
+    function isSet(Config storage self) internal view returns (bool) {
+        return self.delay > 0 || self.nextResetTime > 0;
+    }
+
+    /**
+     * @dev Tells the information related to a time-lock
+     * @param self Time-lock config to be queried
+     */
+    function getTimeLock(Config storage self) internal view returns (uint256 delay, uint256 nextResetTime) {
+        return (self.delay, self.nextResetTime);
+    }
+
+    /**
+     * @dev Initializes a time-lock config
+     * @param self Time-lock config to be updated
+     * @param initialDelay Initial delay to be set
+     * @param delay New delay to be set
+     */
+    function initialize(Config storage self, uint256 initialDelay, uint256 delay) internal {
+        setInitialDelay(self, initialDelay);
+        setDelay(self, delay);
+    }
+
+    /**
+     * @dev Updates the delay of a time-lock config
+     * @param self Time-lock config to be updated
+     * @param delay New delay to be set
+     */
+    function setDelay(Config storage self, uint256 delay) internal {
+        self.delay = delay;
+    }
+
+    /**
+     * @dev Sets the initial delay for a time-lock, it must have not been set before
+     * @param self Time-lock config to be updated
+     * @param delay Initial delay to be set
+     */
+    function setInitialDelay(Config storage self, uint256 delay) private {
+        require(!isSet(self), 'TIME_LOCK_ALREADY_INITIALIZED');
+        self.nextResetTime = block.timestamp + delay;
+    }
+}

--- a/packages/base/contracts/test/config/TimeLockMock.sol
+++ b/packages/base/contracts/test/config/TimeLockMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.3;
+
+import '../../config/TimeLock.sol';
+
+contract TimeLockMock {
+    using TimeLock for TimeLock.Config;
+
+    TimeLock.Config internal timeLock;
+
+    function validate() external {
+        return timeLock.validate();
+    }
+
+    function isValid() external view returns (bool) {
+        return timeLock.isValid();
+    }
+
+    function isSet() external view returns (bool) {
+        return timeLock.isSet();
+    }
+
+    function getTimeLock() external view returns (uint256 delay, uint256 nextResetTime) {
+        return timeLock.getTimeLock();
+    }
+
+    function initialize(uint256 initialDelay, uint256 delay) external {
+        timeLock.initialize(initialDelay, delay);
+    }
+
+    function setDelay(uint256 delay) external {
+        return timeLock.setDelay(delay);
+    }
+}

--- a/packages/base/test/config/TimeLock.test.ts
+++ b/packages/base/test/config/TimeLock.test.ts
@@ -80,7 +80,7 @@ describe('TimeLock', () => {
         await expect(config.validate()).not.to.be.reverted
       })
 
-      it('is not updated', async () => {
+      it('is not updated when validated', async () => {
         const previousTimeLock = await config.getTimeLock()
 
         await config.validate()
@@ -117,7 +117,7 @@ describe('TimeLock', () => {
           await config.initialize(initialDelay, delay)
         })
 
-        it('reverts', async () => {
+        it('applies the time-lock correctly', async () => {
           expect(await config.isValid()).to.be.false
           await expect(config.validate()).to.be.revertedWith('TIME_LOCK_FORBIDDEN')
 

--- a/packages/base/test/config/TimeLock.test.ts
+++ b/packages/base/test/config/TimeLock.test.ts
@@ -1,0 +1,137 @@
+import { advanceTime, currentTimestamp, deploy, MONTH } from '@mimic-fi/v2-helpers'
+import { expect } from 'chai'
+import { Contract } from 'ethers'
+
+describe('TimeLock', () => {
+  let config: Contract
+
+  beforeEach('deploy time-lock config', async () => {
+    config = await deploy('TimeLockMock')
+  })
+
+  describe('initialize', () => {
+    const delay = MONTH
+
+    context('when the time-lock has not been initialized before', () => {
+      context('when no initial delay was set', () => {
+        const initialDelay = 0
+
+        it('can be initialized', async () => {
+          expect(await config.isSet()).to.be.false
+
+          await config.initialize(initialDelay, delay)
+          expect(await config.isSet()).to.be.true
+
+          const now = await currentTimestamp()
+          const timeLock = await config.getTimeLock()
+          expect(timeLock.delay).to.be.equal(delay)
+          expect(timeLock.nextResetTime).to.be.equal(now)
+        })
+      })
+
+      context('when an initial delay is set', () => {
+        const initialDelay = 2 * MONTH
+
+        it('can be initialized', async () => {
+          expect(await config.isSet()).to.be.false
+
+          await config.initialize(initialDelay, delay)
+          expect(await config.isSet()).to.be.true
+
+          const now = await currentTimestamp()
+          const timeLock = await config.getTimeLock()
+          expect(timeLock.delay).to.be.equal(delay)
+          expect(timeLock.nextResetTime).to.be.equal(now.add(initialDelay))
+        })
+      })
+    })
+
+    context('when the time-lock has been initialized before', () => {
+      context('when no initial delay was set', () => {
+        beforeEach('initialize', async () => {
+          await config.setDelay(delay)
+        })
+
+        it('reverts', async () => {
+          expect(await config.isSet()).to.be.true
+          await expect(config.initialize(0, delay)).to.be.revertedWith('TIME_LOCK_ALREADY_INITIALIZED')
+        })
+      })
+
+      context('when an initial delay was set', () => {
+        const initialDelay = 2 * MONTH
+
+        beforeEach('initialize', async () => {
+          await config.initialize(initialDelay, delay)
+        })
+
+        it('reverts', async () => {
+          expect(await config.isSet()).to.be.true
+          await expect(config.initialize(initialDelay, delay)).to.be.revertedWith('TIME_LOCK_ALREADY_INITIALIZED')
+        })
+      })
+    })
+  })
+
+  describe('validate', () => {
+    context('when the time-lock has not been initialized', () => {
+      it('is considered valid', async () => {
+        expect(await config.isValid()).to.be.true
+        await expect(config.validate()).not.to.be.reverted
+      })
+
+      it('is not updated', async () => {
+        const previousTimeLock = await config.getTimeLock()
+
+        await config.validate()
+
+        const currentTimeLock = await config.getTimeLock()
+        expect(currentTimeLock.delay).to.be.equal(previousTimeLock.delay)
+        expect(currentTimeLock.nextResetTime).to.be.equal(previousTimeLock.nextResetTime)
+      })
+    })
+
+    context('when the time-lock has been initialized', () => {
+      const delay = MONTH
+
+      context('when no initial delay was set', () => {
+        beforeEach('initialize', async () => {
+          await config.setDelay(delay)
+        })
+
+        it('applies the time-lock correctly', async () => {
+          expect(await config.isValid()).to.be.true
+          await expect(config.validate()).not.to.be.reverted
+
+          const now = await currentTimestamp()
+          const timeLock = await config.getTimeLock()
+          expect(timeLock.delay).to.be.equal(delay)
+          expect(timeLock.nextResetTime).to.be.equal(now.add(delay))
+        })
+      })
+
+      context('when an initial delay was set', () => {
+        const initialDelay = 2 * MONTH
+
+        beforeEach('initialize', async () => {
+          await config.initialize(initialDelay, delay)
+        })
+
+        it('reverts', async () => {
+          expect(await config.isValid()).to.be.false
+          await expect(config.validate()).to.be.revertedWith('TIME_LOCK_FORBIDDEN')
+
+          await advanceTime(initialDelay)
+
+          expect(await config.isValid()).to.be.true
+          await expect(config.validate()).not.to.be.reverted
+
+          const now = await currentTimestamp()
+          const timeLock = await config.getTimeLock()
+          expect(timeLock.delay).to.be.equal(delay)
+          expect(timeLock.nextResetTime).to.be.equal(now.add(delay))
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Time-lock configs are basically defined by two concepts: a delay and an initial delay.
The initial delay is optional an is enforced only once, the delay is enforced every time the config is bumped. 