### PR TITLE
Base: Implement oracled actions

### DIFF
--- a/packages/base/contracts/actions/OracledAction.sol
+++ b/packages/base/contracts/actions/OracledAction.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.3;
+
+import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+import './BaseAction.sol';
+
+/**
+ * @dev Action that can work with off-chain passed feed data from trusted oracles.
+ * It relies on a specific "extra-calldata" layout as follows:
+ *
+ * [ feed 1 | feed 2 | ... | feed n | n | v | r | s ]
+ *
+ * For simplicity, we use full 256 bit slots for 'n', 'v', 'r', and 's' values.
+ * Note that 'n' denotes the number of encoded feeds, while [v,r,s] denote the corresponding oracle signature.
+ * Each feed has the following 4-words layout:
+ *
+ * [ base | quote | rate | deadline ]
+ */
+abstract contract OracledAction is BaseAction {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /**
+     * @dev Feed data
+     * @param base Token to rate
+     * @param quote Token used for the price rate
+     * @param rate Price of a token (base) expressed in `quote`. It must use the corresponding number of decimals so
+     *             that when performing a fixed point product of it by a `base` amount, the result is expressed in
+     *             `quote` decimals. For example, if `base` is ETH and `quote` is USDC, the number of decimals of `rate`
+     *             must be 6: FixedPoint.mul(X[ETH], rate[USDC/ETH]) = FixedPoint.mul(X[18], price[6]) = X * price [6].
+     * @param deadline Expiration timestamp until when the given quote is considered valid
+     */
+    struct FeedData {
+        address base;
+        address quote;
+        uint256 rate;
+        uint256 deadline;
+    }
+
+    // Enumerable set of trusted signers
+    EnumerableSet.AddressSet private signers;
+
+    /**
+     * @dev Emitted every time a signer condition is changed
+     */
+    event OracleSignerSet(address indexed signer, bool allowed);
+
+    /**
+     * @dev Change an oracle signer condition
+     * @param signer Address of the signer being queried
+     * @param allowed Whether the signer should be allowed or not
+     * @return success True if the signer was actually added or removed from the list of oracle signers
+     */
+    function setOracleSigner(address signer, bool allowed) external auth returns (bool success) {
+        require(signer != address(0), 'ORACLED_SIGNER_ZERO');
+        success = allowed ? signers.add(signer) : signers.remove(signer);
+        if (success) emit OracleSignerSet(signer, allowed);
+    }
+
+    /**
+     * @dev Tells the list of oracle signers
+     */
+    function getOracleSigners() external view returns (address[] memory) {
+        return signers.values();
+    }
+
+    /**
+     * @dev Tells whether an address is as an oracle signer or not
+     * @param signer Address of the signer being queried
+     */
+    function isOracleSigner(address signer) public view returns (bool) {
+        return signers.contains(signer);
+    }
+
+    /**
+     * @dev Hashes the list of feeds
+     * @param feeds List of feeds to be hashed
+     */
+    function getFeedsDigest(FeedData[] memory feeds) public pure returns (bytes32) {
+        return keccak256(abi.encode(feeds));
+    }
+
+    /**
+     * @dev Tries fetching a price for base/quote pair from any potential encoded off-chain oracle data. Otherwise
+     * it fallbacks to the smart vault's price oracle. Off-chain oracle data is only used when it can be trusted, this
+     * is: well-formed, signed by an allowed oracle, and up-to-date.
+     */
+    function _getPrice(address base, address quote) internal view returns (uint256) {
+        (FeedData[] memory feeds, address signer) = _getEncodedOracleData();
+
+        if (signer != address(0) && isOracleSigner(signer)) {
+            for (uint256 i = 0; i < feeds.length; i++) {
+                FeedData memory feed = feeds[i];
+                if (feed.base == base && feed.quote == quote) {
+                    require(feed.deadline >= block.timestamp, 'ORACLE_FEED_OUTDATED');
+                    return feed.rate;
+                }
+            }
+        }
+
+        return smartVault.getPrice(base, quote);
+    }
+
+    /**
+     * @dev Decodes any potential encoded off-chain oracle data.
+     * @return feeds List of feeds encoded in the extra calldata.
+     * @return signer Address recovered from the encoded signature in the extra calldata. A zeroed address is invalid.
+     */
+    function _getEncodedOracleData() private pure returns (FeedData[] memory feeds, address signer) {
+        feeds = _getOracleFeeds();
+        bytes32 message = ECDSA.toEthSignedMessageHash(getFeedsDigest(feeds));
+        uint8 v = _getOracleSignatureV();
+        bytes32 r = _getOracleSignatureR();
+        bytes32 s = _getOracleSignatureS();
+        signer = ecrecover(message, v, r, s);
+    }
+
+    /**
+     * @dev Extracts the list of feeds encoded in the extra calldata. This function returns bogus data if there is no
+     * extra calldata in place. The last feed is stored using the first four words right before the feeds length.
+     */
+    function _getOracleFeeds() private pure returns (FeedData[] memory feeds) {
+        feeds = new FeedData[](_getFeedsLength());
+        for (uint256 i = 0; i < feeds.length; i++) {
+            uint256 pos = 4 * (feeds.length - i);
+            FeedData memory feed = feeds[i];
+            feed.base = address(uint160(uint256(_decodeCalldataWord(pos + 3))));
+            feed.quote = address(uint160(uint256(_decodeCalldataWord(pos + 2))));
+            feed.rate = uint256(_decodeCalldataWord(pos + 1));
+            feed.deadline = uint256(_decodeCalldataWord(pos));
+        }
+    }
+
+    /**
+     * @dev Extracts the number of feeds encoded in the extra calldata. This function returns bogus data if there is no
+     * extra calldata in place. The number of encoded feeds is encoded in the 4th word from the calldata end.
+     */
+    function _getFeedsLength() private pure returns (uint256) {
+        return uint256(_decodeCalldataWord(3));
+    }
+
+    /**
+     * @dev Extracts the component V of the oracle signature parameter from extra calldata. This function returns bogus
+     * data if no signature is included. This is not a security risk, as that data would not be considered a valid
+     * signature in the first place. The component V is encoded in the 3rd word from the calldata end.
+     */
+    function _getOracleSignatureV() private pure returns (uint8) {
+        return uint8(uint256(_decodeCalldataWord(2)));
+    }
+
+    /**
+     * @dev Extracts the component R of the oracle signature parameter from extra calldata. This function returns bogus
+     * data if no signature is included. This is not a security risk, as that data would not be considered a valid
+     * signature in the first place. The component R is encoded in the 2nd word from the calldata end.
+     */
+    function _getOracleSignatureR() private pure returns (bytes32) {
+        return _decodeCalldataWord(1);
+    }
+
+    /**
+     * @dev Extracts the component S of the oracle signature parameter from extra calldata. This function returns bogus
+     * data if no signature is included. This is not a security risk, as that data would not be considered a valid
+     * signature in the first place. The component S is encoded in the last word from the calldata end.
+     */
+    function _getOracleSignatureS() private pure returns (bytes32) {
+        return _decodeCalldataWord(0);
+    }
+
+    /**
+     * @dev Returns the nth 256 bit word starting from the calldata end (0 means the last calldata word).
+     * This function returns bogus data if no signature is included.
+     */
+    function _decodeCalldataWord(uint256 n) private pure returns (bytes32 result) {
+        assembly {
+            result := calldataload(sub(calldatasize(), mul(0x20, add(n, 1))))
+        }
+    }
+}

--- a/packages/base/contracts/test/actions/OracledActionMock.sol
+++ b/packages/base/contracts/test/actions/OracledActionMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import '../../actions/OracledAction.sol';
+
+contract OracledActionMock is OracledAction {
+    event LogPrice(uint256 price);
+
+    constructor(address admin, address registry) BaseAction(admin, registry) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function getPrice(address base, address quote) external {
+        emit LogPrice(_getPrice(base, quote));
+    }
+}

--- a/packages/base/index.ts
+++ b/packages/base/index.ts
@@ -1,3 +1,4 @@
 export * from './src/asserts'
+export * from './src/oracle'
 export * from './src/samples'
 export * from './src/setup'

--- a/packages/base/src/oracle.ts
+++ b/packages/base/src/oracle.ts
@@ -1,0 +1,33 @@
+import { BigNumberish } from '@mimic-fi/v2-helpers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { Contract, ethers } from 'ethers'
+import { defaultAbiCoder, hexValue, hexZeroPad, splitSignature } from 'ethers/lib/utils'
+
+export type FeedData = { base: string; quote: string; rate: BigNumberish; deadline: BigNumberish }
+
+export async function buildExtraFeedData(
+  action: Contract,
+  feeds: FeedData[],
+  signer: SignerWithAddress
+): Promise<string> {
+  const message = await action.getFeedsDigest(feeds)
+  const signature = await signer.signMessage(ethers.utils.arrayify(message))
+  const { v, r, s } = splitSignature(signature)
+  const encodedV = hexZeroPad(hexValue(v), 32).slice(2)
+  const encodedR = r.slice(2)
+  const encodedS = s.slice(2)
+  const encodedFeeds = encodeFeedsData(feeds)
+  return `0x${encodedFeeds}${encodedV}${encodedR}${encodedS}`
+}
+
+export function encodeFeedsData(feeds: FeedData[]): string {
+  let encodedFeeds = ''
+  for (const feed of feeds) encodedFeeds += encodeFeedData(feed)
+  return encodedFeeds + defaultAbiCoder.encode(['uint256'], [feeds.length]).slice(2)
+}
+
+export function encodeFeedData(feed: FeedData): string {
+  return defaultAbiCoder
+    .encode(['address', 'address', 'uint256', 'uint256'], [feed.base, feed.quote, feed.rate, feed.deadline])
+    .slice(2)
+}

--- a/packages/base/test/actions/OracledAction.test.ts
+++ b/packages/base/test/actions/OracledAction.test.ts
@@ -1,0 +1,287 @@
+import {
+  advanceTime,
+  assertEvent,
+  assertIndirectEvent,
+  assertNoEvent,
+  currentTimestamp,
+  DAY,
+  fp,
+  getSigner,
+  getSigners,
+} from '@mimic-fi/v2-helpers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { expect } from 'chai'
+import { BigNumber, Contract } from 'ethers'
+
+import { createAction, createSmartVault, createTokenMock, Mimic, setupMimic } from '../../dist'
+import { buildExtraFeedData, FeedData } from '../../src/oracle'
+import { createPriceFeedMock } from '../../src/samples'
+
+describe('OracledAction', () => {
+  let action: Contract, smartVault: Contract, mimic: Mimic, owner: SignerWithAddress
+
+  before('set up signers', async () => {
+    // eslint-disable-next-line prettier/prettier
+    [, owner] = await getSigners()
+  })
+
+  beforeEach('deploy action', async () => {
+    mimic = await setupMimic(true)
+    smartVault = await createSmartVault(mimic, owner)
+    action = await createAction('OracledActionMock', mimic, owner, smartVault)
+  })
+
+  describe('setOracleSigner', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('authorize sender', async () => {
+        const setOracleSignerRole = action.interface.getSighash('setOracleSigner')
+        await action.connect(owner).authorize(owner.address, setOracleSignerRole)
+        action = action.connect(owner)
+      })
+
+      context('when allowing the signer', () => {
+        const allowed = true
+
+        context('when the signer was not allowed', () => {
+          it('allows the signer', async () => {
+            await action.setOracleSigner(owner.address, allowed)
+            expect(await action.isOracleSigner(owner.address)).to.be.true
+          })
+
+          it('emits an event', async () => {
+            const tx = await action.setOracleSigner(owner.address, allowed)
+            await assertEvent(tx, 'OracleSignerSet', { signer: owner, allowed })
+          })
+        })
+
+        context('when the signer was not allowed', () => {
+          beforeEach('allow signer', async () => {
+            await action.setOracleSigner(owner.address, true)
+          })
+
+          it('does not affect the signer condition', async () => {
+            await action.setOracleSigner(owner.address, allowed)
+            expect(await action.isOracleSigner(owner.address)).to.be.true
+          })
+
+          it('does not emit an event', async () => {
+            const tx = await action.setOracleSigner(owner.address, allowed)
+            await assertNoEvent(tx, 'OracleSignerSet')
+          })
+        })
+      })
+
+      context('when removing the signer', () => {
+        const allowed = false
+
+        context('when the signer was not allowed', () => {
+          it('does not affect the signer condition', async () => {
+            await action.setOracleSigner(owner.address, allowed)
+            expect(await action.isOracleSigner(owner.address)).to.be.false
+          })
+
+          it('does not emit an event', async () => {
+            const tx = await action.setOracleSigner(owner.address, allowed)
+            await assertNoEvent(tx, 'OracleSignerSet')
+          })
+        })
+
+        context('when the signer was allowed', () => {
+          beforeEach('allow signer', async () => {
+            await action.setOracleSigner(owner.address, true)
+          })
+
+          it('removes the oracle signer', async () => {
+            await action.setOracleSigner(owner.address, allowed)
+            expect(await action.isOracleSigner(owner.address)).to.be.false
+          })
+
+          it('emits an event', async () => {
+            const tx = await action.setOracleSigner(owner.address, allowed)
+            await assertEvent(tx, 'OracleSignerSet', { signer: owner, allowed })
+          })
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      it('reverts', async () => {
+        await expect(action.setOracleSigner(owner.address, true)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('getPrice', () => {
+    let base: Contract, quote: Contract, feed: Contract, extraCallData: string
+
+    const OFF_CHAIN_ORACLE_PRICE = fp(5)
+    const SMART_VAULT_ORACLE_PRICE = fp(10)
+
+    before('deploy base and quote', async () => {
+      base = await createTokenMock('BASE')
+      quote = await createTokenMock('QUOTE')
+      feed = await createPriceFeedMock(SMART_VAULT_ORACLE_PRICE)
+    })
+
+    const setUpSmartVaultOracleFeed = () => {
+      beforeEach('set smart vault oracle', async () => {
+        const setPriceFeedRole = smartVault.interface.getSighash('setPriceFeed')
+        await smartVault.connect(owner).authorize(owner.address, setPriceFeedRole)
+        await smartVault.connect(owner).setPriceFeed(base.address, quote.address, feed.address)
+      })
+    }
+
+    const itRetrievesThePriceFromTheSmartVaultOracle = () => {
+      it('retrieves the pair price from the smart vault oracle', async () => {
+        expect(await getPrice()).to.be.equal(SMART_VAULT_ORACLE_PRICE)
+      })
+    }
+
+    const itRetrievesThePriceFromTheOffChainFeed = () => {
+      it('retrieves the pair price from the off-chain feed', async () => {
+        expect(await getPrice()).to.be.equal(OFF_CHAIN_ORACLE_PRICE)
+      })
+    }
+
+    const itRevertsDueToMissingFeed = () => {
+      it('reverts due to missing feed', async () => {
+        await expect(getPrice()).to.be.revertedWith('MISSING_PRICE_FEED')
+      })
+    }
+
+    const getPrice = async (): Promise<BigNumber> => {
+      const defaultCallData = await action.populateTransaction.getPrice(base.address, quote.address)
+      const signer = await getSigner()
+      const callData = `${defaultCallData.data}${(extraCallData || '').replace('0x', '')}`
+      const tx = await signer.sendTransaction({ to: action.address, data: callData })
+      const event = await assertIndirectEvent(tx, action.interface, 'LogPrice')
+      return event.args.price
+    }
+
+    context('when there is no off-chain feed given', () => {
+      context('when there is no feed in the smart vault oracle', () => {
+        itRevertsDueToMissingFeed()
+      })
+
+      context('when there is a feed in the smart vault oracle', () => {
+        setUpSmartVaultOracleFeed()
+        itRetrievesThePriceFromTheSmartVaultOracle()
+      })
+    })
+
+    context('when the feed data is well-formed', () => {
+      let feedsData: FeedData[]
+
+      const itRetrievesPricesProperly = () => {
+        context('when the feed data is properly signed', () => {
+          beforeEach('sign with known signer', async () => {
+            const signer = await getSigner(2)
+            extraCallData = await buildExtraFeedData(action, feedsData, signer)
+
+            const setOracleSignerRole = action.interface.getSighash('setOracleSigner')
+            await action.connect(owner).authorize(owner.address, setOracleSignerRole)
+            await action.connect(owner).setOracleSigner(signer.address, true)
+          })
+
+          context('when the feed data is up-to-date', () => {
+            context('when there is no feed in the smart vault oracle', () => {
+              itRetrievesThePriceFromTheOffChainFeed()
+            })
+
+            context('when there is a feed in the smart vault oracle', () => {
+              setUpSmartVaultOracleFeed()
+              itRetrievesThePriceFromTheOffChainFeed()
+            })
+          })
+
+          context('when the feed data is outdated', () => {
+            beforeEach('advance time', async () => {
+              await advanceTime(DAY * 2)
+            })
+
+            const itRevertsDueToOutdatedFeed = () => {
+              it('reverts due to outdated feed', async () => {
+                await expect(getPrice()).to.be.revertedWith('ORACLE_FEED_OUTDATED')
+              })
+            }
+
+            context('when there is no feed in the smart vault oracle', () => {
+              itRevertsDueToOutdatedFeed()
+            })
+
+            context('when there is a feed in the smart vault oracle', () => {
+              setUpSmartVaultOracleFeed()
+              itRevertsDueToOutdatedFeed()
+            })
+          })
+        })
+
+        context('when the feed data is not properly signed', () => {
+          beforeEach('sign with unknown signer', async () => {
+            const signer = await getSigner(2)
+            extraCallData = await buildExtraFeedData(action, feedsData, signer)
+          })
+
+          context('when there is no feed in the smart vault oracle', () => {
+            itRevertsDueToMissingFeed()
+          })
+
+          context('when there is a feed in the smart vault oracle', () => {
+            setUpSmartVaultOracleFeed()
+            itRetrievesThePriceFromTheSmartVaultOracle()
+          })
+        })
+      }
+
+      context('when there is only one feed given', () => {
+        beforeEach('build feed data', async () => {
+          feedsData = [
+            {
+              base: base.address,
+              quote: quote.address,
+              rate: OFF_CHAIN_ORACLE_PRICE,
+              deadline: (await currentTimestamp()).add(DAY),
+            },
+          ]
+        })
+
+        itRetrievesPricesProperly()
+      })
+
+      context('when there are many feeds given', () => {
+        let anotherBase: Contract, anotherQuote: Contract
+
+        before('deploy another base and quote', async () => {
+          anotherBase = await createTokenMock('ANOTHER_BASE')
+          anotherQuote = await createTokenMock('ANOTHER_QUOTE')
+        })
+
+        beforeEach('build feed data', async () => {
+          const deadline = (await currentTimestamp()).add(DAY)
+          feedsData = [
+            { base: base.address, quote: anotherQuote.address, rate: OFF_CHAIN_ORACLE_PRICE.mul(2), deadline },
+            { base: base.address, quote: quote.address, rate: OFF_CHAIN_ORACLE_PRICE, deadline },
+            { base: anotherBase.address, quote: anotherQuote.address, rate: OFF_CHAIN_ORACLE_PRICE.mul(3), deadline },
+          ]
+        })
+
+        itRetrievesPricesProperly()
+      })
+    })
+
+    context('when the feed data is malformed', () => {
+      beforeEach('set malformed extra calldata', async () => {
+        extraCallData = '0xaabbccdd'
+      })
+
+      context('when there is no feed in the smart vault oracle', () => {
+        itRevertsDueToMissingFeed()
+      })
+
+      context('when there is a feed in the smart vault oracle', () => {
+        setUpSmartVaultOracleFeed()
+        itRetrievesThePriceFromTheSmartVaultOracle()
+      })
+    })
+  })
+})


### PR DESCRIPTION
The main idea behind this PR is to allow passing off-chain oracle data as part of the "extra-calldata" layout that can be used by actions, always using the smart vault oracle as a fallback.