### PR TITLE
Mimic: Parameterize amount in funder action

### DIFF
--- a/packages/mimic-fee-collector/contracts/actions/FunderV2.sol
+++ b/packages/mimic-fee-collector/contracts/actions/FunderV2.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+import '@mimic-fi/v2-helpers/contracts/math/FixedPoint.sol';
+import '@mimic-fi/v2-helpers/contracts/utils/Denominations.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/BaseAction.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/WithdrawalAction.sol';
+
+contract FunderV2 is BaseAction, WithdrawalAction {
+    using FixedPoint for uint256;
+
+    address public tokenIn;
+    uint256 public minBalance;
+    uint256 public maxBalance;
+    uint256 public maxSlippage;
+
+    event TokenInSet(address indexed tokenIn);
+    event MaxSlippageSet(uint256 maxSlippage);
+    event BalanceLimitsSet(uint256 min, uint256 max);
+
+    constructor(
+        address _smartVault,
+        address _tokenIn,
+        uint256 _minBalance,
+        uint256 _maxBalance,
+        uint256 _maxSlippage,
+        address _recipient,
+        address _admin,
+        address _owner,
+        address _registry
+    ) BaseAction(_owner, _registry) {
+        require(address(_smartVault) != address(0), 'SMART_VAULT_ZERO');
+        smartVault = ISmartVault(_smartVault);
+        emit SmartVaultSet(_smartVault);
+
+        _setTokenIn(_tokenIn);
+        _setBalanceLimits(_minBalance, _maxBalance);
+        _setMaxSlippage(_maxSlippage);
+
+        require(_recipient != address(0), 'RECIPIENT_ZERO');
+        recipient = _recipient;
+        emit RecipientSet(_recipient);
+
+        _authorize(_admin, BaseAction.setSmartVault.selector);
+        _authorize(_admin, FunderV2.setTokenIn.selector);
+        _authorize(_admin, FunderV2.setBalanceLimits.selector);
+        _authorize(_admin, FunderV2.setMaxSlippage.selector);
+        _authorize(_admin, WithdrawalAction.setRecipient.selector);
+    }
+
+    function fundeableAmount() public view returns (uint256) {
+        if (recipient.balance >= minBalance) return 0;
+
+        uint256 diff = maxBalance - recipient.balance;
+        if (_isWrappedOrNativeToken(tokenIn)) return diff;
+
+        uint256 price = smartVault.getPrice(smartVault.wrappedNativeToken(), tokenIn);
+        return diff.mulUp(price);
+    }
+
+    function canExecute(uint256 amountIn, uint256 slippage) external view returns (bool) {
+        return
+            recipient != address(0) &&
+            tokenIn != address(0) &&
+            minBalance > 0 &&
+            maxBalance > 0 &&
+            amountIn <= fundeableAmount() &&
+            slippage <= maxSlippage;
+    }
+
+    function setTokenIn(address token) external auth {
+        _setTokenIn(token);
+    }
+
+    function setBalanceLimits(uint256 min, uint256 max) external auth {
+        _setBalanceLimits(min, max);
+    }
+
+    function setMaxSlippage(uint256 newMaxSlippage) external auth {
+        _setMaxSlippage(newMaxSlippage);
+    }
+
+    function call(uint8 source, uint256 amountIn, uint256 slippage, bytes memory data) external auth nonReentrant {
+        require(recipient != address(0), 'FUNDER_RECIPIENT_NOT_SET');
+        require(minBalance > 0, 'FUNDER_BALANCE_LIMIT_NOT_SET');
+        require(tokenIn != address(0), 'FUNDER_TOKEN_IN_NOT_SET');
+        require(amountIn > 0, 'FUNDER_AMOUNT_IN_ZERO');
+        require(amountIn <= fundeableAmount(), 'FUNDER_AMOUNT_IN_ABOVE_MAX');
+        require(slippage <= maxSlippage, 'FUNDER_SLIPPAGE_ABOVE_MAX');
+
+        uint256 toWithdraw = Denominations.isNativeToken(tokenIn) ? amountIn : _swap(source, amountIn, slippage, data);
+        _withdraw(Denominations.NATIVE_TOKEN, toWithdraw);
+        emit Executed();
+    }
+
+    function _swap(uint8 source, uint256 amountIn, uint256 slippage, bytes memory data) private returns (uint256) {
+        address wrappedNativeToken = smartVault.wrappedNativeToken();
+        uint256 toUnwrap = tokenIn == wrappedNativeToken
+            ? amountIn
+            : smartVault.swap(
+                source,
+                tokenIn,
+                wrappedNativeToken,
+                amountIn,
+                ISmartVault.SwapLimit.Slippage,
+                slippage,
+                data
+            );
+        return smartVault.unwrap(toUnwrap, new bytes(0));
+    }
+
+    function _setTokenIn(address token) private {
+        require(token != address(0), 'FUNDER_TOKEN_IN_ZERO');
+        tokenIn = token;
+        emit TokenInSet(token);
+    }
+
+    function _setBalanceLimits(uint256 min, uint256 max) private {
+        require(min <= max, 'FUNDER_MIN_GT_MAX');
+        minBalance = min;
+        maxBalance = max;
+        emit BalanceLimitsSet(min, max);
+    }
+
+    function _setMaxSlippage(uint256 newMaxSlippage) private {
+        require(newMaxSlippage <= FixedPoint.ONE, 'SWAPPER_SLIPPAGE_ABOVE_ONE');
+        maxSlippage = newMaxSlippage;
+        emit MaxSlippageSet(newMaxSlippage);
+    }
+}

--- a/packages/mimic-fee-collector/test/actions/FunderV2.test.ts
+++ b/packages/mimic-fee-collector/test/actions/FunderV2.test.ts
@@ -1,0 +1,680 @@
+import {
+  assertAlmostEqual,
+  assertEvent,
+  assertIndirectEvent,
+  deploy,
+  fp,
+  getSigners,
+  NATIVE_TOKEN_ADDRESS,
+  ZERO_ADDRESS,
+} from '@mimic-fi/v2-helpers'
+import {
+  createPriceFeedMock,
+  createSmartVault,
+  createTokenMock,
+  Mimic,
+  setupMimic,
+} from '@mimic-fi/v2-smart-vaults-base'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { expect } from 'chai'
+import { BigNumber, Contract } from 'ethers'
+import { ethers } from 'hardhat'
+
+describe('FunderV2', () => {
+  let action: Contract, smartVault: Contract, mimic: Mimic
+  let owner: SignerWithAddress, other: SignerWithAddress, recipient: SignerWithAddress
+
+  before('set up signers', async () => {
+    // eslint-disable-next-line prettier/prettier
+    [, owner, other, recipient] = await getSigners()
+  })
+
+  beforeEach('deploy action', async () => {
+    mimic = await setupMimic(true)
+    smartVault = await createSmartVault(mimic, owner)
+    action = await deploy('FunderV2', [
+      smartVault.address,
+      (await createTokenMock()).address,
+      fp(1),
+      fp(10),
+      fp(0.001),
+      recipient.address,
+      owner.address,
+      owner.address,
+      mimic.registry.address,
+    ])
+  })
+
+  describe('setTokenIn', () => {
+    let tokenIn: Contract
+
+    beforeEach('deploy token in', async () => {
+      tokenIn = await createTokenMock()
+    })
+
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setTokenInRole = action.interface.getSighash('setTokenIn')
+        await action.connect(owner).authorize(owner.address, setTokenInRole)
+        action = action.connect(owner)
+      })
+
+      context('when the given address is not zero', () => {
+        const itCanSetTheTokenProperly = () => {
+          it('sets the token in', async () => {
+            await action.setTokenIn(tokenIn.address)
+
+            expect(await action.tokenIn()).to.be.equal(tokenIn.address)
+          })
+
+          it('emits an event', async () => {
+            const tx = await action.setTokenIn(tokenIn.address)
+
+            await assertEvent(tx, 'TokenInSet', { tokenIn })
+          })
+        }
+
+        context('when the token in was set', () => {
+          beforeEach('set the token', async () => {
+            await action.setTokenIn(tokenIn.address)
+          })
+
+          itCanSetTheTokenProperly()
+        })
+
+        context('when the token out was not set', () => {
+          itCanSetTheTokenProperly()
+        })
+      })
+
+      context('when the given address is zero', () => {
+        it('reverts', async () => {
+          await expect(action.setTokenIn(ZERO_ADDRESS)).to.be.revertedWith('FUNDER_TOKEN_IN_ZERO')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setTokenIn(tokenIn.address)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('setBalanceLimits', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setBalanceLimitsRole = action.interface.getSighash('setBalanceLimits')
+        await action.connect(owner).authorize(owner.address, setBalanceLimitsRole)
+        action = action.connect(owner)
+      })
+
+      const itSetsBalanceLimitsCorrectly = (min: number, max: number) => {
+        it('sets the balance limits', async () => {
+          await action.setBalanceLimits(min, max)
+
+          expect(await action.minBalance()).to.be.equal(min)
+          expect(await action.maxBalance()).to.be.equal(max)
+        })
+
+        it('emits an event', async () => {
+          const tx = await action.setBalanceLimits(min, max)
+
+          await assertEvent(tx, 'BalanceLimitsSet', { min, max })
+        })
+      }
+
+      context('when the min balance is not zero', () => {
+        const min = 2
+
+        context('when the max balance is not zero', () => {
+          context('when the max balance is greater than the min balance', () => {
+            const max = 5
+
+            itSetsBalanceLimitsCorrectly(min, max)
+          })
+
+          context('when the max balance is lower than the min balance', () => {
+            const max = 1
+
+            it('reverts', async () => {
+              await expect(action.setBalanceLimits(min, max)).to.be.revertedWith('FUNDER_MIN_GT_MAX')
+            })
+          })
+        })
+
+        context('when the max balance is zero', () => {
+          const max = 0
+
+          it('reverts', async () => {
+            await expect(action.setBalanceLimits(min, max)).to.be.revertedWith('FUNDER_MIN_GT_MAX')
+          })
+        })
+      })
+
+      context('when the min balance is zero', () => {
+        const min = 0
+
+        context('when the max balance is not zero', () => {
+          const max = 5
+
+          itSetsBalanceLimitsCorrectly(min, max)
+        })
+
+        context('when the max balance is zero', () => {
+          const max = 0
+
+          itSetsBalanceLimitsCorrectly(min, max)
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setBalanceLimits(0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('setMaxSlippage', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setMaxSlippageRole = action.interface.getSighash('setMaxSlippage')
+        await action.connect(owner).authorize(owner.address, setMaxSlippageRole)
+        action = action.connect(owner)
+      })
+
+      context('when the slippage is not above one', () => {
+        const slippage = fp(1)
+
+        it('sets the slippage', async () => {
+          await action.setMaxSlippage(slippage)
+
+          expect(await action.maxSlippage()).to.be.equal(slippage)
+        })
+
+        it('emits an event', async () => {
+          const tx = await action.setMaxSlippage(slippage)
+
+          await assertEvent(tx, 'MaxSlippageSet', { maxSlippage: slippage })
+        })
+      })
+
+      context('when the slippage is above one', () => {
+        const slippage = fp(1).add(1)
+
+        it('reverts', async () => {
+          await expect(action.setMaxSlippage(slippage)).to.be.revertedWith('SLIPPAGE_ABOVE_ONE')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setMaxSlippage(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('call', () => {
+    const minBalance = fp(10)
+    const maxBalance = fp(20)
+
+    beforeEach('authorize action', async () => {
+      const withdrawRole = smartVault.interface.getSighash('withdraw')
+      await smartVault.connect(owner).authorize(action.address, withdrawRole)
+    })
+
+    beforeEach('set balance limits', async () => {
+      const setBalanceLimitsRole = action.interface.getSighash('setBalanceLimits')
+      await action.connect(owner).authorize(owner.address, setBalanceLimitsRole)
+      await action.connect(owner).setBalanceLimits(minBalance, maxBalance)
+    })
+
+    beforeEach('set recipient', async () => {
+      const setRecipientRole = action.interface.getSighash('setRecipient')
+      await action.connect(owner).authorize(owner.address, setRecipientRole)
+      await action.connect(owner).setRecipient(recipient.address)
+    })
+
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const callRole = action.interface.getSighash('call')
+        await action.connect(owner).authorize(owner.address, callRole)
+        action = action.connect(owner)
+      })
+
+      const fundRecipient = async (balance: BigNumber) => {
+        const current = await ethers.provider.getBalance(recipient.address)
+        if (current.lt(balance)) await other.sendTransaction({ to: recipient.address, value: balance.sub(current) })
+        else await recipient.sendTransaction({ to: other.address, value: current.sub(balance) })
+      }
+
+      context('when the token in is the native token', () => {
+        const tokenIn = NATIVE_TOKEN_ADDRESS
+
+        beforeEach('fund smart vault', async () => {
+          await other.sendTransaction({ to: smartVault.address, value: maxBalance })
+        })
+
+        beforeEach('set token in', async () => {
+          const setTokenInRole = action.interface.getSighash('setTokenIn')
+          await action.connect(owner).authorize(owner.address, setTokenInRole)
+          await action.connect(owner).setTokenIn(tokenIn)
+        })
+
+        context('when the current balance is below the min', () => {
+          const balance = minBalance.sub(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          context('when requesting up to the max balance', () => {
+            let amountIn: BigNumber
+
+            beforeEach('set amount in', async () => {
+              amountIn = await action.fundeableAmount()
+            })
+
+            it('can execute', async () => {
+              expect(await action.canExecute(amountIn, 0)).to.be.true
+            })
+
+            it('computes the fundeable amount correctly', async () => {
+              const currentBalance = await ethers.provider.getBalance(recipient.address)
+              const expectedAmount = maxBalance.sub(currentBalance)
+              expect(await action.fundeableAmount()).to.be.equal(expectedAmount)
+            })
+
+            it('transfers tokens to the recipient', async () => {
+              const previousRecipientBalance = await ethers.provider.getBalance(recipient.address)
+              const previousSmartVaultBalance = await ethers.provider.getBalance(smartVault.address)
+
+              await action.call(0, amountIn, 0, '0x')
+
+              const currentRecipientBalance = await ethers.provider.getBalance(recipient.address)
+              expect(currentRecipientBalance).to.be.eq(previousRecipientBalance.add(amountIn))
+
+              const currentSmartVaultBalance = await ethers.provider.getBalance(smartVault.address)
+              expect(currentSmartVaultBalance).to.be.eq(previousSmartVaultBalance.sub(amountIn))
+            })
+
+            it('calls withdraw primitive', async () => {
+              const tx = await action.call(0, amountIn, 0, '0x')
+
+              await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
+                token: NATIVE_TOKEN_ADDRESS,
+                recipient,
+                withdrawn: amountIn,
+                fee: 0,
+                data: '0x',
+              })
+            })
+
+            it('emits an Executed event', async () => {
+              const tx = await action.call(0, amountIn, 0, '0x')
+
+              await assertEvent(tx, 'Executed')
+            })
+          })
+
+          context('when requesting more than the max balance', () => {
+            let amountIn: BigNumber
+
+            beforeEach('set amount in', async () => {
+              amountIn = (await action.fundeableAmount()).add(1)
+            })
+
+            it('reverts', async () => {
+              await expect(action.call(0, amountIn, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+            })
+          })
+        })
+
+        context('when the current balance is between the min and the max', () => {
+          const balance = maxBalance.sub(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          it('reverts', async () => {
+            await expect(action.call(0, 1, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+          })
+
+          it('computes the fundeable amount correctly', async () => {
+            expect(await action.fundeableAmount()).to.be.equal(0)
+          })
+        })
+
+        context('when the current balance is above the max', () => {
+          const balance = maxBalance.add(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          it('reverts', async () => {
+            await expect(action.call(0, 1, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+          })
+
+          it('computes the fundeable amount correctly', async () => {
+            expect(await action.fundeableAmount()).to.be.equal(0)
+          })
+        })
+      })
+
+      context('when the token in is the wrapped native token', () => {
+        let tokenIn: Contract
+
+        beforeEach('fund smart vault', async () => {
+          tokenIn = mimic.wrappedNativeToken
+          await tokenIn.connect(other).deposit({ value: maxBalance })
+          await tokenIn.connect(other).transfer(smartVault.address, maxBalance)
+        })
+
+        beforeEach('set token in', async () => {
+          const setTokenInRole = action.interface.getSighash('setTokenIn')
+          await action.connect(owner).authorize(owner.address, setTokenInRole)
+          await action.connect(owner).setTokenIn(tokenIn.address)
+        })
+
+        beforeEach('authorize action', async () => {
+          const unwrapRole = smartVault.interface.getSighash('unwrap')
+          await smartVault.connect(owner).authorize(action.address, unwrapRole)
+        })
+
+        context('when the current balance is below the min', () => {
+          const balance = minBalance.sub(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          context('when requesting up to the max balance', () => {
+            let amountIn: BigNumber
+
+            beforeEach('set amount in', async () => {
+              amountIn = await action.fundeableAmount()
+            })
+
+            it('can execute', async () => {
+              expect(await action.canExecute(amountIn, 0)).to.be.true
+            })
+
+            it('computes the fundeable amount correctly', async () => {
+              const currentBalance = await ethers.provider.getBalance(recipient.address)
+              const expectedAmount = maxBalance.sub(currentBalance)
+              expect(await action.fundeableAmount()).to.be.equal(expectedAmount)
+            })
+
+            it('transfers tokens to the recipient', async () => {
+              const previousRecipientBalance = await ethers.provider.getBalance(recipient.address)
+              const previousSmartVaultBalance = await tokenIn.balanceOf(smartVault.address)
+
+              await action.call(0, amountIn, 0, '0x')
+
+              const currentRecipientBalance = await ethers.provider.getBalance(recipient.address)
+              expect(currentRecipientBalance).to.be.eq(previousRecipientBalance.add(amountIn))
+
+              const currentSmartVaultBalance = await tokenIn.balanceOf(smartVault.address)
+              expect(currentSmartVaultBalance).to.be.eq(previousSmartVaultBalance.sub(amountIn))
+            })
+
+            it('calls unwrap and withdraw primitive', async () => {
+              const tx = await action.call(0, amountIn, 0, '0x')
+
+              await assertIndirectEvent(tx, smartVault.interface, 'Unwrap', {
+                amount: amountIn,
+                unwrapped: amountIn,
+                data: '0x',
+              })
+
+              await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
+                token: NATIVE_TOKEN_ADDRESS,
+                recipient,
+                withdrawn: amountIn,
+                fee: 0,
+                data: '0x',
+              })
+            })
+
+            it('emits an Executed event', async () => {
+              const tx = await action.call(0, amountIn, 0, '0x')
+
+              await assertEvent(tx, 'Executed')
+            })
+          })
+
+          context('when requesting more than the max balance', () => {
+            let amountIn: BigNumber
+
+            beforeEach('set amount in', async () => {
+              amountIn = (await action.fundeableAmount()).add(1)
+            })
+
+            it('reverts', async () => {
+              await expect(action.call(0, amountIn, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+            })
+          })
+        })
+
+        context('when the current balance is between the min and the max', () => {
+          const balance = maxBalance.sub(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          it('reverts', async () => {
+            await expect(action.call(0, 1, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+          })
+
+          it('computes the fundeable amount correctly', async () => {
+            expect(await action.fundeableAmount()).to.be.equal(0)
+          })
+        })
+
+        context('when the current balance is above the max', () => {
+          const balance = maxBalance.add(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          it('reverts', async () => {
+            await expect(action.call(0, 1, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+          })
+
+          it('computes the fundeable amount correctly', async () => {
+            expect(await action.fundeableAmount()).to.be.equal(0)
+          })
+        })
+      })
+
+      context('when the token in is another token', () => {
+        let tokenIn: Contract
+        const rate = fp(1.5)
+
+        beforeEach('fund smart vault', async () => {
+          tokenIn = await createTokenMock()
+          await tokenIn.mint(smartVault.address, maxBalance)
+        })
+
+        beforeEach('set token in', async () => {
+          const setTokenInRole = action.interface.getSighash('setTokenIn')
+          await action.connect(owner).authorize(owner.address, setTokenInRole)
+          await action.connect(owner).setTokenIn(tokenIn.address)
+        })
+
+        beforeEach('fund swap connector', async () => {
+          await mimic.swapConnector.mockRate(rate)
+          await mimic.wrappedNativeToken.connect(other).deposit({ value: maxBalance })
+          await mimic.wrappedNativeToken.connect(other).transfer(await mimic.swapConnector.dex(), maxBalance)
+        })
+
+        beforeEach('set price feed', async () => {
+          const feed = await createPriceFeedMock(rate)
+          const setPriceFeedRole = smartVault.interface.getSighash('setPriceFeed')
+          await smartVault.connect(owner).authorize(owner.address, setPriceFeedRole)
+          await smartVault.connect(owner).setPriceFeed(tokenIn.address, mimic.wrappedNativeToken.address, feed.address)
+        })
+
+        beforeEach('authorize action', async () => {
+          const swapRole = smartVault.interface.getSighash('swap')
+          await smartVault.connect(owner).authorize(action.address, swapRole)
+          const unwrapRole = smartVault.interface.getSighash('unwrap')
+          await smartVault.connect(owner).authorize(action.address, unwrapRole)
+        })
+
+        context('when the current balance is below the min', () => {
+          const balance = minBalance.sub(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          context('when requesting up to the max balance', () => {
+            let amountIn: BigNumber
+
+            beforeEach('set amount in', async () => {
+              amountIn = await action.fundeableAmount()
+            })
+
+            context('when the slippage is below the limit', () => {
+              const slippage = fp(0.001)
+
+              beforeEach('set max slippage', async () => {
+                const setMaxSlippageRole = action.interface.getSighash('setMaxSlippage')
+                await action.connect(owner).authorize(owner.address, setMaxSlippageRole)
+                await action.connect(owner).setMaxSlippage(slippage)
+              })
+
+              it('can execute', async () => {
+                expect(await action.canExecute(amountIn, slippage)).to.be.true
+              })
+
+              it('computes the fundeable amount correctly', async () => {
+                const currentBalance = await ethers.provider.getBalance(recipient.address)
+                const expectedAmount = maxBalance.sub(currentBalance).mul(fp(1)).div(rate)
+                assertAlmostEqual(await action.fundeableAmount(), expectedAmount, 1e-15)
+              })
+
+              it('transfers tokens to the recipient', async () => {
+                const previousRecipientBalance = await ethers.provider.getBalance(recipient.address)
+                const previousSmartVaultBalance = await tokenIn.balanceOf(smartVault.address)
+
+                await action.call(0, amountIn, slippage, '0x')
+
+                const expectedAmountOut = amountIn.mul(rate).div(fp(1))
+                const currentRecipientBalance = await ethers.provider.getBalance(recipient.address)
+                expect(currentRecipientBalance).to.be.equal(previousRecipientBalance.add(expectedAmountOut))
+
+                const currentSmartVaultBalance = await tokenIn.balanceOf(smartVault.address)
+                expect(currentSmartVaultBalance).to.be.equal(previousSmartVaultBalance.sub(amountIn))
+              })
+
+              it('calls swap, unwrap, and withdraw primitive', async () => {
+                const tx = await action.call(5, amountIn, slippage, '0xabcd')
+
+                await assertIndirectEvent(tx, smartVault.interface, 'Swap', {
+                  source: 5,
+                  tokenIn,
+                  tokenOut: mimic.wrappedNativeToken.address,
+                  amountIn,
+                  data: '0xabcd',
+                })
+
+                await assertIndirectEvent(tx, smartVault.interface, 'Unwrap', { data: '0x' })
+
+                await assertIndirectEvent(tx, smartVault.interface, 'Withdraw', {
+                  token: NATIVE_TOKEN_ADDRESS,
+                  recipient,
+                  fee: 0,
+                  data: '0x',
+                })
+              })
+
+              it('emits an Executed event', async () => {
+                const tx = await action.call(0, amountIn, slippage, '0x')
+
+                await assertEvent(tx, 'Executed')
+              })
+            })
+
+            context('when the slippage is above the limit', () => {
+              const slippage = fp(1)
+
+              it('reverts', async () => {
+                await expect(action.call(0, 1, slippage, '0x')).to.be.revertedWith('FUNDER_SLIPPAGE_ABOVE_MAX')
+              })
+            })
+          })
+
+          context('when requesting more than the max balance', () => {
+            let amountIn: BigNumber
+
+            beforeEach('set amount in', async () => {
+              amountIn = (await action.fundeableAmount()).add(1)
+            })
+
+            it('reverts', async () => {
+              await expect(action.call(0, amountIn, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+            })
+          })
+        })
+
+        context('when the current balance is between the min and the max', () => {
+          const balance = maxBalance.sub(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          it('reverts', async () => {
+            await expect(action.call(0, 1, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+          })
+
+          it('computes the fundeable amount correctly', async () => {
+            expect(await action.fundeableAmount()).to.be.equal(0)
+          })
+        })
+
+        context('when the current balance is above the max', () => {
+          const balance = maxBalance.add(1)
+
+          beforeEach('fund recipient', async () => {
+            await fundRecipient(balance)
+          })
+
+          it('reverts', async () => {
+            await expect(action.call(0, 1, 0, '0x')).to.be.revertedWith('FUNDER_AMOUNT_IN_ABOVE_MAX')
+          })
+
+          it('computes the fundeable amount correctly', async () => {
+            expect(await action.fundeableAmount()).to.be.equal(0)
+          })
+        })
+      })
+    })
+
+    context('when the sender is authorized', () => {
+      it('reverts', async () => {
+        await expect(action.call(0, 0, 0, '0x')).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR improves the funder action of Mimic's fee collector SV making the amount to be funded an external parameter instead of computing it on-chain. Previous approach introduced weird scenarios where the bot could be computing a swap path for a certain amount that might change when executed on-chain. 