### PR TITLE
Paraswap: Implement connext bridger action

### DIFF
--- a/packages/paraswap-fee-redistributor/contracts/actions/ConnextBridger.sol
+++ b/packages/paraswap-fee-redistributor/contracts/actions/ConnextBridger.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+import '@mimic-fi/v2-helpers/contracts/math/FixedPoint.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/BaseAction.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/TokenThresholdAction.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/RelayedAction.sol';
+
+contract ConnextBridger is BaseAction, TokenThresholdAction, RelayedAction {
+    using FixedPoint for uint256;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // Base gas amount charged to cover gas payment
+    uint256 public constant override BASE_GAS = 60e3;
+
+    // Connext bridge connector source ID
+    uint8 public constant CONNEXT_BRIDGE_SOURCE = 2;
+
+    uint256 public maxRelayerFeePct;
+    uint256 public destinationChainId;
+    EnumerableSet.AddressSet private allowedTokens;
+
+    event AllowedTokenSet(address indexed token, bool allowed);
+    event MaxRelayerFeePctSet(uint256 maxFeePct);
+    event DestinationChainIdSet(uint256 indexed chainId);
+
+    struct Config {
+        address admin;
+        address registry;
+        address smartVault;
+        address[] allowedTokens;
+        uint256 maxRelayerFeePct;
+        uint256 destinationChainId;
+        address thresholdToken;
+        uint256 thresholdAmount;
+        address relayer;
+        uint256 gasPriceLimit;
+    }
+
+    constructor(Config memory config) BaseAction(config.admin, config.registry) {
+        require(address(config.smartVault) != address(0), 'SMART_VAULT_ZERO');
+        smartVault = ISmartVault(config.smartVault);
+        emit SmartVaultSet(config.smartVault);
+
+        _setMaxRelayerFeePct(config.maxRelayerFeePct);
+        _setDestinationChainId(config.destinationChainId);
+        for (uint256 i = 0; i < config.allowedTokens.length; i++) _setAllowedToken(config.allowedTokens[i], true);
+
+        thresholdToken = config.thresholdToken;
+        thresholdAmount = config.thresholdAmount;
+        emit ThresholdSet(config.thresholdToken, config.thresholdAmount);
+
+        isRelayer[config.relayer] = true;
+        emit RelayerSet(config.relayer, true);
+
+        gasPriceLimit = config.gasPriceLimit;
+        emit LimitsSet(config.gasPriceLimit, 0);
+    }
+
+    function getAllowedTokensLength() external view returns (uint256) {
+        return allowedTokens.length();
+    }
+
+    function getAllowedTokens() external view returns (address[] memory) {
+        return allowedTokens.values();
+    }
+
+    function isTokenAllowed(address token) public view returns (bool) {
+        return allowedTokens.contains(token);
+    }
+
+    function setMaxRelayerFeePct(uint256 newMaxRelayerFeePct) external auth {
+        _setMaxRelayerFeePct(newMaxRelayerFeePct);
+    }
+
+    function setAllowedToken(address token, bool allowed) external auth {
+        _setAllowedToken(token, allowed);
+    }
+
+    function setDestinationChainId(uint256 chainId) external auth {
+        _setDestinationChainId(chainId);
+    }
+
+    function call(address token, uint256 amount, uint256 relayerFee) external auth nonReentrant {
+        _initRelayedTx();
+        require(amount > 0, 'BRIDGER_AMOUNT_ZERO');
+        require(isTokenAllowed(token), 'BRIDGER_TOKEN_NOT_ALLOWED');
+        require(destinationChainId != 0, 'BRIDGER_DEST_CHAIN_NOT_SET');
+        require(relayerFee.divUp(amount) <= maxRelayerFeePct, 'BRIDGER_RELAYER_FEE_ABOVE_MAX');
+        _validateThreshold(token, amount);
+
+        emit Executed();
+        uint256 gasRefund = _payRelayedTx(token);
+        uint256 minAmount = amount - relayerFee - gasRefund;
+
+        smartVault.bridge(
+            CONNEXT_BRIDGE_SOURCE,
+            destinationChainId,
+            token,
+            minAmount,
+            ISmartVault.BridgeLimit.MinAmountOut,
+            minAmount,
+            address(smartVault),
+            abi.encode(relayerFee)
+        );
+    }
+
+    function _setAllowedToken(address token, bool allowed) private {
+        require(token != address(0), 'BRIDGER_TOKEN_ZERO');
+        if (allowed ? allowedTokens.add(token) : allowedTokens.remove(token)) {
+            emit AllowedTokenSet(token, allowed);
+        }
+    }
+
+    function _setMaxRelayerFeePct(uint256 newMaxRelayerFeePct) private {
+        require(newMaxRelayerFeePct <= FixedPoint.ONE, 'BRIDGER_RELAYER_FEE_PCT_GT_ONE');
+        maxRelayerFeePct = newMaxRelayerFeePct;
+        emit MaxRelayerFeePctSet(newMaxRelayerFeePct);
+    }
+
+    function _setDestinationChainId(uint256 chainId) private {
+        require(chainId != block.chainid, 'BRIDGER_SAME_CHAIN_ID');
+        destinationChainId = chainId;
+        emit DestinationChainIdSet(chainId);
+    }
+}

--- a/packages/paraswap-fee-redistributor/contracts/actions/ERC20Claimer2.sol
+++ b/packages/paraswap-fee-redistributor/contracts/actions/ERC20Claimer2.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+import '@mimic-fi/v2-helpers/contracts/math/FixedPoint.sol';
+import '@mimic-fi/v2-helpers/contracts/math/UncheckedMath.sol';
+import '@mimic-fi/v2-swap-connector/contracts/ISwapConnector.sol';
+
+import './BaseClaimer.sol';
+
+contract ERC20Claimer2 is BaseClaimer {
+    using FixedPoint for uint256;
+    using UncheckedMath for uint256;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // Base gas amount charged to cover gas payment
+    uint256 public constant override BASE_GAS = 60e3;
+
+    address public tokenOut;
+    address public swapSigner;
+    uint256 public maxSlippage;
+    EnumerableSet.AddressSet private ignoredTokenSwaps;
+
+    event TokenOutSet(address indexed tokenOut);
+    event SwapSignerSet(address indexed swapSigner);
+    event MaxSlippageSet(uint256 maxSlippage);
+    event IgnoreTokenSwapSet(address indexed token, bool ignored);
+
+    struct Config {
+        address admin;
+        address registry;
+        address smartVault;
+        address feeClaimer;
+        address tokenOut;
+        address swapSigner;
+        uint256 maxSlippage;
+        address[] ignoreTokens;
+        address thresholdToken;
+        uint256 thresholdAmount;
+        address relayer;
+        uint256 gasPriceLimit;
+    }
+
+    constructor(Config memory config) BaseClaimer(config.admin, config.registry) {
+        smartVault = ISmartVault(config.smartVault);
+        emit SmartVaultSet(config.smartVault);
+
+        feeClaimer = config.feeClaimer;
+        emit FeeClaimerSet(config.feeClaimer);
+
+        _setTokenOut(config.tokenOut);
+        _setSwapSigner(config.swapSigner);
+        _setMaxSlippage(config.maxSlippage);
+        for (uint256 i = 0; i < config.ignoreTokens.length; i++) {
+            _setIgnoreTokenSwap(config.ignoreTokens[i], true);
+        }
+
+        thresholdToken = config.thresholdToken;
+        thresholdAmount = config.thresholdAmount;
+        emit ThresholdSet(config.thresholdToken, config.thresholdAmount);
+
+        isRelayer[config.relayer] = true;
+        emit RelayerSet(config.relayer, true);
+
+        gasPriceLimit = config.gasPriceLimit;
+        emit LimitsSet(config.gasPriceLimit, 0);
+    }
+
+    function setTokenOut(address newTokenOut) external auth {
+        _setTokenOut(newTokenOut);
+    }
+
+    function setSwapSigner(address newSwapSigner) external auth {
+        _setSwapSigner(newSwapSigner);
+    }
+
+    function setMaxSlippage(uint256 newMaxSlippage) external auth {
+        _setMaxSlippage(newMaxSlippage);
+    }
+
+    function setIgnoreTokenSwaps(address[] memory tokens, bool[] memory ignores) external auth {
+        require(tokens.length == ignores.length, 'IGNORE_SWAP_TOKENS_INVALID_LEN');
+        for (uint256 i = 0; i < tokens.length; i = i.uncheckedAdd(1)) {
+            _setIgnoreTokenSwap(tokens[i], ignores[i]);
+        }
+    }
+
+    function isTokenSwapIgnored(address token) public view returns (bool) {
+        return ignoredTokenSwaps.contains(token);
+    }
+
+    function getIgnoredTokenSwaps() external view returns (address[] memory) {
+        return ignoredTokenSwaps.values();
+    }
+
+    function canExecute(address token) external view override returns (bool) {
+        return !Denominations.isNativeToken(token) && totalBalance(token) > 0;
+    }
+
+    function call(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 expectedAmountOut,
+        uint256 deadline,
+        bytes memory data,
+        bytes memory sig
+    ) external auth nonReentrant redeemGas(tokenOut) {
+        require(!Denominations.isNativeToken(tokenIn), 'ERC20_CLAIMER_INVALID_TOKEN');
+        _validateSig(tokenIn, amountIn, minAmountOut, expectedAmountOut, deadline, data, sig);
+
+        if (isTokenSwapIgnored(tokenIn)) {
+            // The threshold must be checked against the claimable balance, not against the amount out. The amount out
+            // is computed considering both the claimable balance and the smart vault balance in case of a swap, but
+            // if the token in is ignored, the smart vault balance must be ignored.
+            // We can leverage the call information to rate the claimable balance in the token out:
+            uint256 tokenOutPrice = amountIn.divUp(expectedAmountOut);
+            uint256 tokenOutClaimableBalance = claimableBalance(tokenIn).divDown(tokenOutPrice);
+            _validateThreshold(tokenOut, tokenOutClaimableBalance);
+
+            _claim(tokenIn);
+        } else {
+            // The threshold must be checked against the total balance (claimable balance + smart vault balance) which
+            // is already contemplated in the amount out. We use the min amount out as it represents the minimum
+            // amount of token out tokens we will receive for the swap to validate the threshold.
+            _validateThreshold(tokenOut, minAmountOut);
+            _validateSlippage(minAmountOut, expectedAmountOut);
+
+            _claim(tokenIn);
+            smartVault.swap(
+                uint8(ISwapConnector.Source.ParaswapV5),
+                tokenIn,
+                tokenOut,
+                amountIn,
+                ISmartVault.SwapLimit.MinAmountOut,
+                minAmountOut,
+                data
+            );
+        }
+
+        emit Executed();
+    }
+
+    function _setTokenOut(address newTokenOut) internal {
+        tokenOut = newTokenOut;
+        emit TokenOutSet(newTokenOut);
+    }
+
+    function _setSwapSigner(address newSwapSigner) internal {
+        swapSigner = newSwapSigner;
+        emit SwapSignerSet(newSwapSigner);
+    }
+
+    function _setMaxSlippage(uint256 newMaxSlippage) internal {
+        require(newMaxSlippage <= FixedPoint.ONE, 'CLAIMER_SLIPPAGE_ABOVE_ONE');
+        maxSlippage = newMaxSlippage;
+        emit MaxSlippageSet(newMaxSlippage);
+    }
+
+    function _setIgnoreTokenSwap(address token, bool ignore) internal {
+        if (ignore) ignoredTokenSwaps.add(token);
+        else ignoredTokenSwaps.remove(token);
+        emit IgnoreTokenSwapSet(token, ignore);
+    }
+
+    function _validateSlippage(uint256 minAmountOut, uint256 expectedAmountOut) internal view {
+        require(minAmountOut <= expectedAmountOut, 'MIN_AMOUNT_GT_EXPECTED_AMOUNT');
+        uint256 slippage = FixedPoint.ONE - minAmountOut.divUp(expectedAmountOut);
+        require(slippage <= maxSlippage, 'CLAIMER_SLIPPAGE_TOO_BIG');
+    }
+
+    function _validateSig(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 expectedAmountOut,
+        uint256 deadline,
+        bytes memory data,
+        bytes memory sig
+    ) internal view {
+        bytes32 message = _hash(tokenIn, amountIn, minAmountOut, expectedAmountOut, deadline, data);
+        address signer = ECDSA.recover(ECDSA.toEthSignedMessageHash(message), sig);
+        require(signer == swapSigner, 'INVALID_SWAP_SIGNATURE');
+        require(block.timestamp <= deadline, 'SWAP_DEADLINE_EXPIRED');
+    }
+
+    function _hash(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 expectedAmountOut,
+        uint256 deadline,
+        bytes memory data
+    ) private view returns (bytes32) {
+        bool isBuy = false;
+        return
+            keccak256(
+                abi.encodePacked(tokenIn, tokenOut, isBuy, amountIn, minAmountOut, expectedAmountOut, deadline, data)
+            );
+    }
+}

--- a/packages/paraswap-fee-redistributor/test/actions/ConnextBridger.test.ts
+++ b/packages/paraswap-fee-redistributor/test/actions/ConnextBridger.test.ts
@@ -1,0 +1,449 @@
+import {
+  assertEvent,
+  assertIndirectEvent,
+  assertNoEvent,
+  assertNoIndirectEvent,
+  deploy,
+  fp,
+  getSigners,
+  ZERO_ADDRESS,
+} from '@mimic-fi/v2-helpers'
+import { createSmartVault, createTokenMock, Mimic, setupMimic } from '@mimic-fi/v2-smart-vaults-base'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { expect } from 'chai'
+import { Contract } from 'ethers'
+import { defaultAbiCoder } from 'ethers/lib/utils'
+
+describe('ConnextBridger', () => {
+  let action: Contract, smartVault: Contract, mimic: Mimic
+  let owner: SignerWithAddress, other: SignerWithAddress
+
+  before('set up signers', async () => {
+    // eslint-disable-next-line prettier/prettier
+    [, owner, other] = await getSigners()
+  })
+
+  beforeEach('deploy action', async () => {
+    mimic = await setupMimic(true)
+    smartVault = await createSmartVault(mimic, owner)
+    action = await deploy('ConnextBridger', [
+      {
+        admin: owner.address,
+        registry: mimic.registry.address,
+        smartVault: smartVault.address,
+        allowedTokens: [mimic.wrappedNativeToken.address],
+        maxRelayerFeePct: fp(0.1),
+        destinationChainId: 1,
+        thresholdToken: mimic.wrappedNativeToken.address,
+        thresholdAmount: fp(100),
+        relayer: owner.address,
+        gasPriceLimit: 100e9,
+      },
+    ])
+  })
+
+  describe('initialization', () => {
+    it('initializes the action as expected', async () => {
+      const authorizeRole = action.interface.getSighash('authorize')
+      expect(await action.isAuthorized(owner.address, authorizeRole)).to.be.true
+
+      const unauthorizeRole = action.interface.getSighash('unauthorize')
+      expect(await action.isAuthorized(owner.address, unauthorizeRole)).to.be.true
+
+      expect(await action.registry()).to.be.equal(mimic.registry.address)
+      expect(await action.smartVault()).to.be.equal(smartVault.address)
+      expect(await action.destinationChainId()).to.be.equal(1)
+      expect(await action.maxRelayerFeePct()).to.be.equal(fp(0.1))
+      expect(await action.isTokenAllowed(mimic.wrappedNativeToken.address)).to.be.true
+
+      expect(await action.isRelayer(owner.address)).to.be.true
+      expect(await action.gasPriceLimit()).to.be.eq(100e9)
+      expect(await action.txCostLimit()).to.be.eq(0)
+
+      expect(await action.thresholdToken()).to.be.eq(mimic.wrappedNativeToken.address)
+      expect(await action.thresholdAmount()).to.be.eq(fp(100))
+    })
+  })
+
+  describe('setAllowedToken', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setAllowedTokenRole = action.interface.getSighash('setAllowedToken')
+        await action.connect(owner).authorize(owner.address, setAllowedTokenRole)
+        action = action.connect(owner)
+      })
+
+      context('when the token is not zero', () => {
+        let token: Contract
+
+        beforeEach('set token', async () => {
+          token = mimic.wrappedNativeToken
+        })
+
+        const itConfigsTheTokenCorrectly = (allowed: boolean) => {
+          it(`${allowed ? 'allows' : 'disallows'} the token`, async () => {
+            await action.setAllowedToken(token.address, allowed)
+
+            expect(await action.isTokenAllowed(token.address)).to.be.equal(allowed)
+          })
+        }
+
+        const itEmitsAnEvent = (allowed: boolean) => {
+          it('emits an event', async () => {
+            const tx = await action.setAllowedToken(token.address, allowed)
+
+            await assertEvent(tx, 'AllowedTokenSet', { token, allowed })
+          })
+        }
+
+        const itDoesNotEmitAnEvent = (allowed: boolean) => {
+          it('does not emit an event', async () => {
+            const tx = await action.setAllowedToken(token.address, allowed)
+
+            await assertNoEvent(tx, 'AllowedTokenSet')
+          })
+        }
+
+        context('when allowing the token', () => {
+          const allowed = true
+
+          context('when the token was allowed', () => {
+            beforeEach('allow the token', async () => {
+              await action.setAllowedToken(token.address, true)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itDoesNotEmitAnEvent(allowed)
+          })
+
+          context('when the token was not allowed', () => {
+            beforeEach('disallow the token', async () => {
+              await action.setAllowedToken(token.address, false)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itEmitsAnEvent(allowed)
+          })
+        })
+
+        context('when disallowing the token', () => {
+          const allowed = false
+
+          context('when the token was allowed', () => {
+            beforeEach('allow the token', async () => {
+              await action.setAllowedToken(token.address, true)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itEmitsAnEvent(allowed)
+          })
+
+          context('when the token was not allowed', () => {
+            beforeEach('disallow the token', async () => {
+              await action.setAllowedToken(token.address, false)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itDoesNotEmitAnEvent(allowed)
+          })
+        })
+      })
+
+      context('when the token is zero', () => {
+        const token = ZERO_ADDRESS
+
+        it('reverts', async () => {
+          await expect(action.setAllowedToken(token, true)).to.be.revertedWith('BRIDGER_TOKEN_ZERO')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setAllowedToken(ZERO_ADDRESS, true)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('setDestinationChainId', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setDestinationChainRole = action.interface.getSighash('setDestinationChainId')
+        await action.connect(owner).authorize(owner.address, setDestinationChainRole)
+        action = action.connect(owner)
+      })
+
+      context('when setting the chain ID', () => {
+        const itSetsTheChainCorrectly = () => {
+          context('when the chain ID is not the current one', () => {
+            const chainId = 1
+
+            it('sets the chain ID', async () => {
+              await action.setDestinationChainId(chainId)
+
+              expect(await action.destinationChainId()).to.be.equal(chainId)
+            })
+
+            it('emits an event', async () => {
+              const tx = await action.setDestinationChainId(chainId)
+
+              await assertEvent(tx, 'DestinationChainIdSet', { chainId })
+            })
+          })
+
+          context('when the chain ID is the current one', () => {
+            const chainId = 31337 // Hardhat chain ID
+
+            it('reverts', async () => {
+              await expect(action.setDestinationChainId(chainId)).to.be.revertedWith('BRIDGER_SAME_CHAIN_ID')
+            })
+          })
+        }
+
+        context('when the chain ID was set', () => {
+          beforeEach('set chain ID', async () => {
+            await action.setDestinationChainId(1)
+          })
+
+          itSetsTheChainCorrectly()
+        })
+
+        context('when the chain ID was not set', () => {
+          beforeEach('unset chain ID', async () => {
+            await action.setDestinationChainId(0)
+          })
+
+          itSetsTheChainCorrectly()
+        })
+      })
+
+      context('when unsetting the chain ID', () => {
+        const itUnsetsTheChainCorrectly = () => {
+          it('unsets the chain ID', async () => {
+            await action.setDestinationChainId(0)
+
+            expect(await action.destinationChainId()).to.be.equal(0)
+          })
+
+          it('emits an event', async () => {
+            const tx = await action.setDestinationChainId(0)
+
+            await assertEvent(tx, 'DestinationChainIdSet', { chainId: 0 })
+          })
+        }
+
+        context('when the chain ID was set', () => {
+          beforeEach('set chain ID', async () => {
+            await action.setDestinationChainId(1)
+          })
+
+          itUnsetsTheChainCorrectly()
+        })
+
+        context('when the chain ID was not set', () => {
+          beforeEach('unset chain ID', async () => {
+            await action.setDestinationChainId(0)
+          })
+
+          itUnsetsTheChainCorrectly()
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setDestinationChainId(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('setMaxRelayerFeePct', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setMaxRelayerFeePctRole = action.interface.getSighash('setMaxRelayerFeePct')
+        await action.connect(owner).authorize(owner.address, setMaxRelayerFeePctRole)
+        action = action.connect(owner)
+      })
+
+      context('when the pct is not above one', () => {
+        const pct = fp(0.1)
+
+        it('sets the relayer fee pct', async () => {
+          await action.setMaxRelayerFeePct(pct)
+
+          expect(await action.maxRelayerFeePct()).to.be.equal(pct)
+        })
+
+        it('emits an event', async () => {
+          const tx = await action.setMaxRelayerFeePct(pct)
+
+          await assertEvent(tx, 'MaxRelayerFeePctSet', { maxFeePct: pct })
+        })
+      })
+
+      context('when the pct is above one', () => {
+        const pct = fp(1).add(1)
+
+        it('reverts', async () => {
+          await expect(action.setMaxRelayerFeePct(pct)).to.be.revertedWith('BRIDGER_RELAYER_FEE_PCT_GT_ONE')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setMaxRelayerFeePct(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('call', () => {
+    let token: Contract
+
+    const SOURCE = 2
+    const MAX_RELAYER_FEE_PCT = fp(0.1)
+    const DESTINATION_CHAIN_ID = 5
+
+    beforeEach('deploy token', async () => {
+      token = await createTokenMock()
+    })
+
+    beforeEach('authorize action', async () => {
+      const wrapRole = smartVault.interface.getSighash('wrap')
+      await smartVault.connect(owner).authorize(action.address, wrapRole)
+      const bridgeRole = smartVault.interface.getSighash('bridge')
+      await smartVault.connect(owner).authorize(action.address, bridgeRole)
+    })
+
+    beforeEach('set max relayer fee', async () => {
+      const setMaxRelayerFeePctRole = action.interface.getSighash('setMaxRelayerFeePct')
+      await action.connect(owner).authorize(owner.address, setMaxRelayerFeePctRole)
+      await action.connect(owner).setMaxRelayerFeePct(MAX_RELAYER_FEE_PCT)
+    })
+
+    beforeEach('set destination chain ID', async () => {
+      const setDestinationChainIdRole = action.interface.getSighash('setDestinationChainId')
+      await action.connect(owner).authorize(owner.address, setDestinationChainIdRole)
+      await action.connect(owner).setDestinationChainId(DESTINATION_CHAIN_ID)
+    })
+
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const callRole = action.interface.getSighash('call')
+        await action.connect(owner).authorize(owner.address, callRole)
+        action = action.connect(owner)
+      })
+
+      context('when the amount is greater than zero', () => {
+        const amount = fp(50)
+
+        context('when the given token is allowed', () => {
+          beforeEach('allow token', async () => {
+            const setAllowedTokenRole = action.interface.getSighash('setAllowedToken')
+            await action.connect(owner).authorize(owner.address, setAllowedTokenRole)
+            await action.connect(owner).setAllowedToken(token.address, true)
+          })
+
+          beforeEach('fund smart vault', async () => {
+            await token.mint(smartVault.address, amount)
+          })
+
+          context('when the relayer fee is below the limit', () => {
+            const relayerFee = amount.mul(MAX_RELAYER_FEE_PCT).div(fp(1))
+
+            context('when the current balance passes the threshold', () => {
+              const threshold = amount
+
+              beforeEach('set threshold', async () => {
+                const setThresholdRole = action.interface.getSighash('setThreshold')
+                await action.connect(owner).authorize(owner.address, setThresholdRole)
+                await action.connect(owner).setThreshold(token.address, threshold)
+              })
+
+              it('does not call the wrap primitive', async () => {
+                const tx = await action.call(token.address, amount, relayerFee)
+
+                await assertNoIndirectEvent(tx, smartVault.interface, 'Wrap')
+              })
+
+              it('calls the bridge primitive', async () => {
+                const tx = await action.call(token.address, amount, relayerFee)
+
+                await assertIndirectEvent(tx, smartVault.interface, 'Bridge', {
+                  source: SOURCE,
+                  chainId: DESTINATION_CHAIN_ID,
+                  token,
+                  amountIn: amount.sub(relayerFee),
+                  minAmountOut: amount.sub(relayerFee),
+                  data: defaultAbiCoder.encode(['uint256'], [relayerFee]),
+                })
+              })
+
+              it('emits an Executed event', async () => {
+                const tx = await action.call(token.address, amount, relayerFee)
+
+                await assertEvent(tx, 'Executed')
+              })
+            })
+
+            context('when the current balance does not pass the threshold', () => {
+              const threshold = amount.mul(2)
+
+              beforeEach('set threshold', async () => {
+                const setThresholdRole = action.interface.getSighash('setThreshold')
+                await action.connect(owner).authorize(owner.address, setThresholdRole)
+                await action.connect(owner).setThreshold(token.address, threshold)
+              })
+
+              it('reverts', async () => {
+                await expect(action.call(token.address, amount, relayerFee)).to.be.revertedWith('MIN_THRESHOLD_NOT_MET')
+              })
+            })
+          })
+
+          context('when the relayer fee is above the limit', () => {
+            const relayerFee = amount.mul(MAX_RELAYER_FEE_PCT).div(fp(1)).add(1)
+
+            it('reverts', async () => {
+              await expect(action.call(token.address, amount, relayerFee)).to.be.revertedWith(
+                'BRIDGER_RELAYER_FEE_ABOVE_MAX'
+              )
+            })
+          })
+        })
+
+        context('when the given token is not allowed', () => {
+          it('reverts', async () => {
+            await expect(action.call(token.address, amount, 0)).to.be.revertedWith('BRIDGER_TOKEN_NOT_ALLOWED')
+          })
+        })
+      })
+
+      context('when the requested amount is zero', () => {
+        const amount = 0
+
+        it('reverts', async () => {
+          await expect(action.call(token.address, amount, 0)).to.be.revertedWith('BRIDGER_AMOUNT_ZERO')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      it('reverts', async () => {
+        await expect(action.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces a new action in order to bridge assets using Connext. It introduces the following configs:
- Max relayer fee pct
- Destination chain - ideally mainnet
- List of allowed tokens - ideally to be set to USDC or WETH only

Note that this connector will allow us to bridge assets from polygon, bsc, optimism, gnosis, and arbitrum to mainnet