### PR TITLE
Paraswap: Implement wormhole bridger action

### DIFF
--- a/packages/paraswap-fee-redistributor/contracts/actions/WormholeBridger.sol
+++ b/packages/paraswap-fee-redistributor/contracts/actions/WormholeBridger.sol
@@ -112,7 +112,7 @@ contract WormholeBridger is BaseAction, TokenThresholdAction, RelayedAction {
             WORMHOLE_BRIDGE_SOURCE,
             destinationChainId,
             token,
-            minAmount,
+            amount,
             ISmartVault.BridgeLimit.MinAmountOut,
             minAmount,
             address(smartVault),

--- a/packages/paraswap-fee-redistributor/contracts/actions/WormholeBridger.sol
+++ b/packages/paraswap-fee-redistributor/contracts/actions/WormholeBridger.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+import '@mimic-fi/v2-helpers/contracts/math/FixedPoint.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/BaseAction.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/TokenThresholdAction.sol';
+import '@mimic-fi/v2-smart-vaults-base/contracts/actions/RelayedAction.sol';
+
+contract WormholeBridger is BaseAction, TokenThresholdAction, RelayedAction {
+    using FixedPoint for uint256;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // Base gas amount charged to cover gas payment
+    uint256 public constant override BASE_GAS = 60e3;
+
+    // Wormhole bridge connector source ID
+    uint8 public constant WORMHOLE_BRIDGE_SOURCE = 3;
+
+    uint256 public maxRelayerFeePct;
+    uint256 public destinationChainId;
+    EnumerableSet.AddressSet private allowedTokens;
+
+    event AllowedTokenSet(address indexed token, bool allowed);
+    event MaxRelayerFeePctSet(uint256 maxFeePct);
+    event DestinationChainIdSet(uint256 indexed chainId);
+
+    struct Config {
+        address admin;
+        address registry;
+        address smartVault;
+        address[] allowedTokens;
+        uint256 maxRelayerFeePct;
+        uint256 destinationChainId;
+        address thresholdToken;
+        uint256 thresholdAmount;
+        address relayer;
+        uint256 gasPriceLimit;
+    }
+
+    constructor(Config memory config) BaseAction(config.admin, config.registry) {
+        require(address(config.smartVault) != address(0), 'SMART_VAULT_ZERO');
+        smartVault = ISmartVault(config.smartVault);
+        emit SmartVaultSet(config.smartVault);
+
+        _setMaxRelayerFeePct(config.maxRelayerFeePct);
+        _setDestinationChainId(config.destinationChainId);
+        for (uint256 i = 0; i < config.allowedTokens.length; i++) _setAllowedToken(config.allowedTokens[i], true);
+
+        thresholdToken = config.thresholdToken;
+        thresholdAmount = config.thresholdAmount;
+        emit ThresholdSet(config.thresholdToken, config.thresholdAmount);
+
+        isRelayer[config.relayer] = true;
+        emit RelayerSet(config.relayer, true);
+
+        gasPriceLimit = config.gasPriceLimit;
+        emit LimitsSet(config.gasPriceLimit, 0);
+    }
+
+    function getAllowedTokensLength() external view returns (uint256) {
+        return allowedTokens.length();
+    }
+
+    function getAllowedTokens() external view returns (address[] memory) {
+        return allowedTokens.values();
+    }
+
+    function isTokenAllowed(address token) public view returns (bool) {
+        return allowedTokens.contains(token);
+    }
+
+    function setMaxRelayerFeePct(uint256 newMaxRelayerFeePct) external auth {
+        _setMaxRelayerFeePct(newMaxRelayerFeePct);
+    }
+
+    function setAllowedToken(address token, bool allowed) external auth {
+        _setAllowedToken(token, allowed);
+    }
+
+    function setDestinationChainId(uint256 chainId) external auth {
+        _setDestinationChainId(chainId);
+    }
+
+    function call(address token, uint256 amount, uint256 relayerFee) external auth nonReentrant {
+        _initRelayedTx();
+        require(amount > 0, 'BRIDGER_AMOUNT_ZERO');
+        require(isTokenAllowed(token), 'BRIDGER_TOKEN_NOT_ALLOWED');
+        require(destinationChainId != 0, 'BRIDGER_DEST_CHAIN_NOT_SET');
+        require(relayerFee.divUp(amount) <= maxRelayerFeePct, 'BRIDGER_RELAYER_FEE_ABOVE_MAX');
+        _validateThreshold(token, amount);
+
+        emit Executed();
+        uint256 gasRefund = _payRelayedTx(token);
+        uint256 minAmount = amount - relayerFee - gasRefund;
+
+        smartVault.bridge(
+            WORMHOLE_BRIDGE_SOURCE,
+            destinationChainId,
+            token,
+            minAmount,
+            ISmartVault.BridgeLimit.MinAmountOut,
+            minAmount,
+            address(smartVault),
+            new bytes(0)
+        );
+    }
+
+    function _setAllowedToken(address token, bool allowed) private {
+        require(token != address(0), 'BRIDGER_TOKEN_ZERO');
+        if (allowed ? allowedTokens.add(token) : allowedTokens.remove(token)) {
+            emit AllowedTokenSet(token, allowed);
+        }
+    }
+
+    function _setMaxRelayerFeePct(uint256 newMaxRelayerFeePct) private {
+        require(newMaxRelayerFeePct <= FixedPoint.ONE, 'BRIDGER_RELAYER_FEE_PCT_GT_ONE');
+        maxRelayerFeePct = newMaxRelayerFeePct;
+        emit MaxRelayerFeePctSet(newMaxRelayerFeePct);
+    }
+
+    function _setDestinationChainId(uint256 chainId) private {
+        require(chainId != block.chainid, 'BRIDGER_SAME_CHAIN_ID');
+        destinationChainId = chainId;
+        emit DestinationChainIdSet(chainId);
+    }
+}

--- a/packages/paraswap-fee-redistributor/test/actions/WormholeBridger.test.ts
+++ b/packages/paraswap-fee-redistributor/test/actions/WormholeBridger.test.ts
@@ -1,0 +1,448 @@
+import {
+  assertEvent,
+  assertIndirectEvent,
+  assertNoEvent,
+  assertNoIndirectEvent,
+  deploy,
+  fp,
+  getSigners,
+  ZERO_ADDRESS,
+} from '@mimic-fi/v2-helpers'
+import { createSmartVault, createTokenMock, Mimic, setupMimic } from '@mimic-fi/v2-smart-vaults-base'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { expect } from 'chai'
+import { Contract } from 'ethers'
+
+describe('WormholeBridger', () => {
+  let action: Contract, smartVault: Contract, mimic: Mimic
+  let owner: SignerWithAddress, other: SignerWithAddress
+
+  before('set up signers', async () => {
+    // eslint-disable-next-line prettier/prettier
+      [, owner, other] = await getSigners()
+  })
+
+  beforeEach('deploy action', async () => {
+    mimic = await setupMimic(true)
+    smartVault = await createSmartVault(mimic, owner)
+    action = await deploy('WormholeBridger', [
+      {
+        admin: owner.address,
+        registry: mimic.registry.address,
+        smartVault: smartVault.address,
+        allowedTokens: [mimic.wrappedNativeToken.address],
+        maxRelayerFeePct: fp(0.1),
+        destinationChainId: 1,
+        thresholdToken: mimic.wrappedNativeToken.address,
+        thresholdAmount: fp(100),
+        relayer: owner.address,
+        gasPriceLimit: 100e9,
+      },
+    ])
+  })
+
+  describe('initialization', () => {
+    it('initializes the action as expected', async () => {
+      const authorizeRole = action.interface.getSighash('authorize')
+      expect(await action.isAuthorized(owner.address, authorizeRole)).to.be.true
+
+      const unauthorizeRole = action.interface.getSighash('unauthorize')
+      expect(await action.isAuthorized(owner.address, unauthorizeRole)).to.be.true
+
+      expect(await action.registry()).to.be.equal(mimic.registry.address)
+      expect(await action.smartVault()).to.be.equal(smartVault.address)
+      expect(await action.destinationChainId()).to.be.equal(1)
+      expect(await action.maxRelayerFeePct()).to.be.equal(fp(0.1))
+      expect(await action.isTokenAllowed(mimic.wrappedNativeToken.address)).to.be.true
+
+      expect(await action.isRelayer(owner.address)).to.be.true
+      expect(await action.gasPriceLimit()).to.be.eq(100e9)
+      expect(await action.txCostLimit()).to.be.eq(0)
+
+      expect(await action.thresholdToken()).to.be.eq(mimic.wrappedNativeToken.address)
+      expect(await action.thresholdAmount()).to.be.eq(fp(100))
+    })
+  })
+
+  describe('setAllowedToken', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setAllowedTokenRole = action.interface.getSighash('setAllowedToken')
+        await action.connect(owner).authorize(owner.address, setAllowedTokenRole)
+        action = action.connect(owner)
+      })
+
+      context('when the token is not zero', () => {
+        let token: Contract
+
+        beforeEach('set token', async () => {
+          token = mimic.wrappedNativeToken
+        })
+
+        const itConfigsTheTokenCorrectly = (allowed: boolean) => {
+          it(`${allowed ? 'allows' : 'disallows'} the token`, async () => {
+            await action.setAllowedToken(token.address, allowed)
+
+            expect(await action.isTokenAllowed(token.address)).to.be.equal(allowed)
+          })
+        }
+
+        const itEmitsAnEvent = (allowed: boolean) => {
+          it('emits an event', async () => {
+            const tx = await action.setAllowedToken(token.address, allowed)
+
+            await assertEvent(tx, 'AllowedTokenSet', { token, allowed })
+          })
+        }
+
+        const itDoesNotEmitAnEvent = (allowed: boolean) => {
+          it('does not emit an event', async () => {
+            const tx = await action.setAllowedToken(token.address, allowed)
+
+            await assertNoEvent(tx, 'AllowedTokenSet')
+          })
+        }
+
+        context('when allowing the token', () => {
+          const allowed = true
+
+          context('when the token was allowed', () => {
+            beforeEach('allow the token', async () => {
+              await action.setAllowedToken(token.address, true)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itDoesNotEmitAnEvent(allowed)
+          })
+
+          context('when the token was not allowed', () => {
+            beforeEach('disallow the token', async () => {
+              await action.setAllowedToken(token.address, false)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itEmitsAnEvent(allowed)
+          })
+        })
+
+        context('when disallowing the token', () => {
+          const allowed = false
+
+          context('when the token was allowed', () => {
+            beforeEach('allow the token', async () => {
+              await action.setAllowedToken(token.address, true)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itEmitsAnEvent(allowed)
+          })
+
+          context('when the token was not allowed', () => {
+            beforeEach('disallow the token', async () => {
+              await action.setAllowedToken(token.address, false)
+            })
+
+            itConfigsTheTokenCorrectly(allowed)
+            itDoesNotEmitAnEvent(allowed)
+          })
+        })
+      })
+
+      context('when the token is zero', () => {
+        const token = ZERO_ADDRESS
+
+        it('reverts', async () => {
+          await expect(action.setAllowedToken(token, true)).to.be.revertedWith('BRIDGER_TOKEN_ZERO')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setAllowedToken(ZERO_ADDRESS, true)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('setDestinationChainId', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setDestinationChainRole = action.interface.getSighash('setDestinationChainId')
+        await action.connect(owner).authorize(owner.address, setDestinationChainRole)
+        action = action.connect(owner)
+      })
+
+      context('when setting the chain ID', () => {
+        const itSetsTheChainCorrectly = () => {
+          context('when the chain ID is not the current one', () => {
+            const chainId = 1
+
+            it('sets the chain ID', async () => {
+              await action.setDestinationChainId(chainId)
+
+              expect(await action.destinationChainId()).to.be.equal(chainId)
+            })
+
+            it('emits an event', async () => {
+              const tx = await action.setDestinationChainId(chainId)
+
+              await assertEvent(tx, 'DestinationChainIdSet', { chainId })
+            })
+          })
+
+          context('when the chain ID is the current one', () => {
+            const chainId = 31337 // Hardhat chain ID
+
+            it('reverts', async () => {
+              await expect(action.setDestinationChainId(chainId)).to.be.revertedWith('BRIDGER_SAME_CHAIN_ID')
+            })
+          })
+        }
+
+        context('when the chain ID was set', () => {
+          beforeEach('set chain ID', async () => {
+            await action.setDestinationChainId(1)
+          })
+
+          itSetsTheChainCorrectly()
+        })
+
+        context('when the chain ID was not set', () => {
+          beforeEach('unset chain ID', async () => {
+            await action.setDestinationChainId(0)
+          })
+
+          itSetsTheChainCorrectly()
+        })
+      })
+
+      context('when unsetting the chain ID', () => {
+        const itUnsetsTheChainCorrectly = () => {
+          it('unsets the chain ID', async () => {
+            await action.setDestinationChainId(0)
+
+            expect(await action.destinationChainId()).to.be.equal(0)
+          })
+
+          it('emits an event', async () => {
+            const tx = await action.setDestinationChainId(0)
+
+            await assertEvent(tx, 'DestinationChainIdSet', { chainId: 0 })
+          })
+        }
+
+        context('when the chain ID was set', () => {
+          beforeEach('set chain ID', async () => {
+            await action.setDestinationChainId(1)
+          })
+
+          itUnsetsTheChainCorrectly()
+        })
+
+        context('when the chain ID was not set', () => {
+          beforeEach('unset chain ID', async () => {
+            await action.setDestinationChainId(0)
+          })
+
+          itUnsetsTheChainCorrectly()
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setDestinationChainId(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('setMaxRelayerFeePct', () => {
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const setMaxRelayerFeePctRole = action.interface.getSighash('setMaxRelayerFeePct')
+        await action.connect(owner).authorize(owner.address, setMaxRelayerFeePctRole)
+        action = action.connect(owner)
+      })
+
+      context('when the pct is not above one', () => {
+        const pct = fp(0.1)
+
+        it('sets the relayer fee pct', async () => {
+          await action.setMaxRelayerFeePct(pct)
+
+          expect(await action.maxRelayerFeePct()).to.be.equal(pct)
+        })
+
+        it('emits an event', async () => {
+          const tx = await action.setMaxRelayerFeePct(pct)
+
+          await assertEvent(tx, 'MaxRelayerFeePctSet', { maxFeePct: pct })
+        })
+      })
+
+      context('when the pct is above one', () => {
+        const pct = fp(1).add(1)
+
+        it('reverts', async () => {
+          await expect(action.setMaxRelayerFeePct(pct)).to.be.revertedWith('BRIDGER_RELAYER_FEE_PCT_GT_ONE')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      beforeEach('set sender', () => {
+        action = action.connect(other)
+      })
+
+      it('reverts', async () => {
+        await expect(action.setMaxRelayerFeePct(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+
+  describe('call', () => {
+    let token: Contract
+
+    const SOURCE = 3
+    const MAX_RELAYER_FEE_PCT = fp(0.1)
+    const DESTINATION_CHAIN_ID = 5
+
+    beforeEach('deploy token', async () => {
+      token = await createTokenMock()
+    })
+
+    beforeEach('authorize action', async () => {
+      const wrapRole = smartVault.interface.getSighash('wrap')
+      await smartVault.connect(owner).authorize(action.address, wrapRole)
+      const bridgeRole = smartVault.interface.getSighash('bridge')
+      await smartVault.connect(owner).authorize(action.address, bridgeRole)
+    })
+
+    beforeEach('set max relayer fee', async () => {
+      const setMaxRelayerFeePctRole = action.interface.getSighash('setMaxRelayerFeePct')
+      await action.connect(owner).authorize(owner.address, setMaxRelayerFeePctRole)
+      await action.connect(owner).setMaxRelayerFeePct(MAX_RELAYER_FEE_PCT)
+    })
+
+    beforeEach('set destination chain ID', async () => {
+      const setDestinationChainIdRole = action.interface.getSighash('setDestinationChainId')
+      await action.connect(owner).authorize(owner.address, setDestinationChainIdRole)
+      await action.connect(owner).setDestinationChainId(DESTINATION_CHAIN_ID)
+    })
+
+    context('when the sender is authorized', () => {
+      beforeEach('set sender', async () => {
+        const callRole = action.interface.getSighash('call')
+        await action.connect(owner).authorize(owner.address, callRole)
+        action = action.connect(owner)
+      })
+
+      context('when the amount is greater than zero', () => {
+        const amount = fp(50)
+
+        context('when the given token is allowed', () => {
+          beforeEach('allow token', async () => {
+            const setAllowedTokenRole = action.interface.getSighash('setAllowedToken')
+            await action.connect(owner).authorize(owner.address, setAllowedTokenRole)
+            await action.connect(owner).setAllowedToken(token.address, true)
+          })
+
+          beforeEach('fund smart vault', async () => {
+            await token.mint(smartVault.address, amount)
+          })
+
+          context('when the relayer fee is below the limit', () => {
+            const relayerFee = amount.mul(MAX_RELAYER_FEE_PCT).div(fp(1))
+
+            context('when the current balance passes the threshold', () => {
+              const threshold = amount
+
+              beforeEach('set threshold', async () => {
+                const setThresholdRole = action.interface.getSighash('setThreshold')
+                await action.connect(owner).authorize(owner.address, setThresholdRole)
+                await action.connect(owner).setThreshold(token.address, threshold)
+              })
+
+              it('does not call the wrap primitive', async () => {
+                const tx = await action.call(token.address, amount, relayerFee)
+
+                await assertNoIndirectEvent(tx, smartVault.interface, 'Wrap')
+              })
+
+              it('calls the bridge primitive', async () => {
+                const tx = await action.call(token.address, amount, relayerFee)
+
+                await assertIndirectEvent(tx, smartVault.interface, 'Bridge', {
+                  source: SOURCE,
+                  chainId: DESTINATION_CHAIN_ID,
+                  token,
+                  amountIn: amount.sub(relayerFee),
+                  minAmountOut: amount.sub(relayerFee),
+                  data: '0x',
+                })
+              })
+
+              it('emits an Executed event', async () => {
+                const tx = await action.call(token.address, amount, relayerFee)
+
+                await assertEvent(tx, 'Executed')
+              })
+            })
+
+            context('when the current balance does not pass the threshold', () => {
+              const threshold = amount.mul(2)
+
+              beforeEach('set threshold', async () => {
+                const setThresholdRole = action.interface.getSighash('setThreshold')
+                await action.connect(owner).authorize(owner.address, setThresholdRole)
+                await action.connect(owner).setThreshold(token.address, threshold)
+              })
+
+              it('reverts', async () => {
+                await expect(action.call(token.address, amount, relayerFee)).to.be.revertedWith('MIN_THRESHOLD_NOT_MET')
+              })
+            })
+          })
+
+          context('when the relayer fee is above the limit', () => {
+            const relayerFee = amount.mul(MAX_RELAYER_FEE_PCT).div(fp(1)).add(1)
+
+            it('reverts', async () => {
+              await expect(action.call(token.address, amount, relayerFee)).to.be.revertedWith(
+                'BRIDGER_RELAYER_FEE_ABOVE_MAX'
+              )
+            })
+          })
+        })
+
+        context('when the given token is not allowed', () => {
+          it('reverts', async () => {
+            await expect(action.call(token.address, amount, 0)).to.be.revertedWith('BRIDGER_TOKEN_NOT_ALLOWED')
+          })
+        })
+      })
+
+      context('when the requested amount is zero', () => {
+        const amount = 0
+
+        it('reverts', async () => {
+          await expect(action.call(token.address, amount, 0)).to.be.revertedWith('BRIDGER_AMOUNT_ZERO')
+        })
+      })
+    })
+
+    context('when the sender is not authorized', () => {
+      it('reverts', async () => {
+        await expect(action.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+      })
+    })
+  })
+})

--- a/packages/paraswap-fee-redistributor/test/actions/WormholeBridger.test.ts
+++ b/packages/paraswap-fee-redistributor/test/actions/WormholeBridger.test.ts
@@ -384,7 +384,7 @@ describe('WormholeBridger', () => {
                   source: SOURCE,
                   chainId: DESTINATION_CHAIN_ID,
                   token,
-                  amountIn: amount.sub(relayerFee),
+                  amountIn: amount,
                   minAmountOut: amount.sub(relayerFee),
                   data: '0x',
                 })


### PR DESCRIPTION
This PR introduces a new action in order to bridge assets using Wormhole (through CCTP). It introduces the following configs:

- Max relayer fee pct
- Destination chain - ideally mainnet or avalanche only
- List of allowed tokens - ideally to be set to USDC only

Note that this connector will allow us to bridge assets across avalanche and mainnet
